### PR TITLE
Add support for static files

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,12 @@ rye run air
 
 The generated site will be in the `public` directory, with a `hello.html` page generated from the `hello.md` file.
 
+## Adding Static Files
+
+To add static files to your site, place them in the `input` directory. When you run the `air` command, these files will be copied to the `public` directory.
+
+For example, if you have an image file `input/images/logo.png`, it will be copied to `public/images/logo.png`.
+
 ## Deploying to GitHub Pages
 
 First, create a repository on GitHub with your site's domain name as the repository name, e.g. example.github.io

--- a/src/air/__init__.py
+++ b/src/air/__init__.py
@@ -7,5 +7,6 @@ def main() -> int:
     generator = StaticSiteGenerator("input", "public")
     generator.register_plugin(MarkdownPlugin)
     generator.build()
+    generator.copy_static_files()
     print("Site built from input/ to public/")
     return 0

--- a/src/air/generator.py
+++ b/src/air/generator.py
@@ -50,3 +50,13 @@ class StaticSiteGenerator:
 
         for plugin in self.plugins:
             plugin.run()
+
+        self.copy_static_files()
+
+    def copy_static_files(self) -> None:
+        for path in self.source_dir.rglob("*"):
+            if path.is_file() and not path.suffix in [".html", ".md"]:
+                relative_path = path.relative_to(self.source_dir)
+                output_path = self.output_dir / relative_path
+                output_path.parent.mkdir(parents=True, exist_ok=True)
+                shutil.copy2(path, output_path)


### PR DESCRIPTION
Add functionality to copy static files from the `input` directory to the `public` directory.

* **StaticSiteGenerator class**:
  - Add `copy_static_files` method to copy static files from `input` to `public`.
  - Call `copy_static_files` method in the `build` method after rendering templates.

* **Main function**:
  - Call the `copy_static_files` method after building the site in the `main` function.

* **README.md**:
  - Add instructions for adding static files to the `input` directory.
  - Explain that static files will be copied to the `public` directory.


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/feldroy/air?shareId=800ce345-47e1-4082-8d39-10a74af550ec).