### PR TITLE
docs: fix link to audrey.feldroy.com in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # air
 
-An ultra-lightweight static site generator created by [https://audrey.feldroy.com](@audreyfeldroy).
+An ultra-lightweight static site generator created by [@audreyfeldroy](https://audrey.feldroy.com).
 
 * Project homepage and documentation: https://air.feldroy.com
 * GitHub repo: https://github.com/feldroy/air


### PR DESCRIPTION
I noticed that this link pointed to https://github.com/feldroy/air/blob/main/@audreyfeldroy, which led to a 404