### PR TITLE
Improve install docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,7 +2,7 @@
 
 Make sure you have [uv](https://docs.astral.sh/uv/getting-started/installation/) installed.
 
-Clone the repository and install the dependencies:
+Fork and clone this repository, and install the dependencies:
 
 ```bash
 git clone https://github.com/feldroy/air.git

--- a/README.md
+++ b/README.md
@@ -21,8 +21,14 @@ Planned features
 
 ## Installation
 
+If you are a more advanced user who plans to contribute to Air (and we invite you to!), follow the install instructions in CONTRIBUTING.md instead of the following.
+
+Otherwise, create a virtualenv and install the air package, like:
+
 ```sh
-pip install air
+uv venv
+source .venv/bin/activate
+uv add air
 ```
 
 ## Use with fastapi tags


### PR DESCRIPTION
* Explicitly tell users to create a uv virtualenv, to minimize risk of dependency conflicts
* Encourage contributor setup
* Have future contributors fork the repo