### PR TITLE
Shortcut renderer for jinja2

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,8 +5,9 @@
 Current Features 
 
 - Designed to work with FastAPI so you can have your API and web pages server from one app
-- HTML generation from jinja2 or Python classes. Pick one or both!
-- ⁠Shortcut Response  class and fastapi tags
+- When it comes to HTML generation, Jinja2 and Air tags are both first class citizens 
+- ⁠Shortcut Response class for jinja2 rendering
+- Air tags, for quick HTML content generation using Pythonc lasses
 - Built from the beginning with ⁠HTMX in mind
 - ⁠Shortcut utility functions galore
 - Static site generation
@@ -16,7 +17,6 @@ Current Features
 Planned features
 
 - ⁠pydantic-powered html forms
-- ⁠Shortcut Response class for jinja2
 
 
 ## Installation
@@ -31,7 +31,7 @@ source .venv/bin/activate
 uv add air
 ```
 
-## Use with fastapi tags
+## Use Air with tags
 
 ```python
 from fastapi import FastAPI
@@ -43,6 +43,22 @@ app = FastAPI()
 @app.get("/", response_class=TagResponse)
 async def index():
     return air.Html(air.H1("Hello, world!", style="color: blue;"))
+```
+
+## Use Air with Jinja2 shortcut
+
+```python
+from air import Jinja2Renderer
+
+render = Jinja2Renderer(directory="tests/templates")
+
+@app.get("/test")
+def test_endpoint(request: Request):
+    return render(
+        request,
+        name="home.html",
+        context={"title": "Test Page", "content": "Hello, World!"},
+    )
 ```
 
 ## Generate HTML and API

--- a/src/air/__init__.py
+++ b/src/air/__init__.py
@@ -4,6 +4,7 @@ __version__ = "0.5.0"
 
 from .requests import is_htmx_request as is_htmx_request
 from .responses import TagResponse as TagResponse
+from .templates import Jinja2Renderer as Jinja2Renderer
 from .tags import Tag as Tag
 from .tags import (
     A as A,

--- a/src/air/templates.py
+++ b/src/air/templates.py
@@ -1,0 +1,36 @@
+from fastapi import Request
+from fastapi.templating import Jinja2Templates
+from typing import Any
+
+
+class Jinja2Renderer:
+    """Template renderer to make Jinja2 easier in Air.
+
+    Args:
+        directory: Template directory
+
+    Example:
+        >>> # Instantiate the render callable
+        >>> render = TemplateRenderer('templates')
+        >>>
+        >>> # Use for returning Jinja2 from views
+        >>> @app.get('/')
+        >>> async def home(request: Request):
+        >>> return render(
+        ...     request,
+        ...     'home.html',
+        ...     context={'id': 5}
+        ... )
+    """
+
+    def __init__(self, directory: str):
+        self.templates = Jinja2Templates(directory=directory)
+
+    def __call__(
+        self, request: Request, name: str, context: dict[Any, Any] | None = None
+    ):
+        if context is None:
+            context = {}
+        return self.templates.TemplateResponse(
+            request=request, name=name, context=context
+        )

--- a/tests/templates/home.html
+++ b/tests/templates/home.html
@@ -1,0 +1,4 @@
+<html>
+<title>{{title}}</title>
+<h1>{{content}}</h1>
+</html>

--- a/tests/test_templates.py
+++ b/tests/test_templates.py
@@ -1,0 +1,47 @@
+from air import Jinja2Renderer
+
+from fastapi import FastAPI, Request
+from fastapi.testclient import TestClient
+
+
+def test_Jinja2Renderer():
+    """Test the Jinja2Renderer class."""
+    app = FastAPI()
+
+    render = Jinja2Renderer(directory="tests/templates")
+
+    @app.get("/test")
+    def test_endpoint(request: Request):
+        return render(
+            request,
+            name="home.html",
+            context={"title": "Test Page", "content": "Hello, World!"},
+        )
+
+    client = TestClient(app)
+    response = client.get("/test")
+
+    assert response.status_code == 200
+    assert response.headers["content-type"] == "text/html; charset=utf-8"
+    assert (
+        response.text
+        == "<html>\n<title>Test Page</title>\n<h1>Hello, World!</h1>\n</html>"
+    )
+
+
+def test_Jinja2Renderer_no_context():
+    """Test the Jinja2Renderer class."""
+    app = FastAPI()
+
+    render = Jinja2Renderer(directory="tests/templates")
+
+    @app.get("/test")
+    def test_endpoint(request: Request):
+        return render(request, name="home.html")
+
+    client = TestClient(app)
+    response = client.get("/test")
+
+    assert response.status_code == 200
+    assert response.headers["content-type"] == "text/html; charset=utf-8"
+    assert response.text == "<html>\n<title></title>\n<h1></h1>\n</html>"


### PR DESCRIPTION
1. Introduces `templates.Jinja2Renderer`, wraps FastAPI/Starlette Jinja2 generator
2. Adds tests to support new class
3. API is designed to shorten characters typed to return a Jinja2-powered response

For #21 