### PR TITLE
Convert Tag.children to for loop and fix bug

### DIFF
--- a/docs/air-tags.md
+++ b/docs/air-tags.md
@@ -79,9 +79,37 @@ This will produce the following HTML:
 <awesome class="desert">Ice Cream</awesome>
 ```
 
-## More complex custom Air Tags
+## Functions as Custom Air Tags 
 
-For this to be documented, these tickets need to be resolved:
+Subclasses are not the only way to create custom Air Tags. You can also use functions to create Air Tags. This is particularly useful for putting together components quickly without needing to define a class. Here's an example of a function that creates a custom Air Tag for a [picocss card](https://picocss.com/docs/card):
 
-- https://github.com/feldroy/air/issues/57
-- https://github.com/feldroy/air/issues/44
+```python
+def card(*content, header:str, footer:str):
+    return air.Article(
+        air.Header(header),
+        *content,
+        air.Footer(footer)
+    )
+```
+
+We can use this function to create a card:
+
+```python
+card(
+    air.P("This is a card with some content."),
+    air.P("It can have multiple paragraphs."),
+    header="Card Header",
+    footer="Card Footer",
+).render()
+```
+
+Which produces the following HTML:
+
+```html
+<article>
+    <header>Card Header</header>
+    <p>This is a card with some content.</p>
+    <p>It can have multiple paragraphs.</p>
+    <footer>Card Footer</footer>
+</article>
+```

--- a/src/air/tags.py
+++ b/src/air/tags.py
@@ -52,9 +52,22 @@ class Tag:
 
     @cached_property
     def children(self):
-        return "".join(
-            [c.render() if isinstance(c, Tag) else c for c in self._children]
-        )
+        elements = []
+        for child in self._children:
+            if isinstance(child, Tag):
+                elements.append(child.render())
+            elif isinstance(child, str):
+                elements.append(child)
+            elif isinstance(child, int):
+                elements.append(str(child))
+            else:
+                # TODO: Produce a better error message
+                msg = f"Unsupported child type: {type(child)}"
+                msg += f"\n in tag {self.name}"
+                msg += f"\n child {child}"
+                msg += f"\n data {self.__dict__}"
+                raise TypeError(msg)
+        return "".join(elements)
 
     def render(self) -> str:
         return f"<{self.name}{self.attrs}>{self.children}</{self.name}>"

--- a/tests/test_tags.py
+++ b/tests/test_tags.py
@@ -130,3 +130,43 @@ def test_raw_html_ignores_kwargs():
     """Test that RawHTML ignores keyword arguments."""
     raw = air.RawHTML("<div>Test</div>", id="ignored", cls="also-ignored")
     assert raw.render() == "<div>Test</div>"
+
+
+def test_functions_as_tags():
+    """Test that functions can be used as tags."""
+
+    def article_preview(title: str, slug: str, description: str):
+        return air.Article(
+            air.H2(air.A(title, href=f"/posts/{slug}")), air.P(description)
+        )
+
+    articles = [
+        article_preview("First Post", "first-post", "This is the first post."),
+        article_preview("Second Post", "second-post", "This is the second post."),
+        article_preview("Third Post", "third-post", "This is the third post."),
+    ]
+
+    content = air.Main(air.H1("Articles"), *articles, air.P("Read more on our blog."))
+    assert isinstance(content.render(), str)
+
+    def layout(*children):
+        return air.Html(*children)
+
+    html = layout(content)
+    assert isinstance(html.render(), str)
+
+
+def test_pico_card():
+    def card(*content, header: str, footer: str):
+        return air.Article(air.Header(header), *content, air.Footer(footer))
+
+    html = card(
+        air.P("This is a card with some content."),
+        header="Card Header",
+        footer="Card Footer",
+    ).render()
+
+    assert (
+        html
+        == "<article><header>Card Header</header><p>This is a card with some content.</p><footer>Card Footer</footer></article>"
+    )


### PR DESCRIPTION
This fixes #57 and #44.

#44 was caused by a `int` type being passed in where only Tags and str had been planned. Need to figure out other types too.