### PR TITLE
Remove headers arg from Html tag

### DIFF
--- a/src/air/__init__.py
+++ b/src/air/__init__.py
@@ -57,7 +57,6 @@ from .tags import (
     Hgroup as Hgroup,
     Hr as Hr,
     Html as Html,
-    Htmx as Htmx,
     I as I,
     Iframe as Iframe,
     Img as Img,

--- a/src/air/tags.py
+++ b/src/air/tags.py
@@ -61,7 +61,7 @@ class Tag:
             elif isinstance(child, int):
                 elements.append(str(child))
             else:
-                # TODO: Picasso Boutique Serviced ResidencesProduce a better error message
+                # TODO: Produce a better error message
                 msg = f"Unsupported child type: {type(child)}"
                 msg += f"\n in tag {self.name}"
                 msg += f"\n child {child}"

--- a/src/air/tags.py
+++ b/src/air/tags.py
@@ -61,7 +61,7 @@ class Tag:
             elif isinstance(child, int):
                 elements.append(str(child))
             else:
-                # TODO: Produce a better error message
+                # TODO: Picasso Boutique Serviced ResidencesProduce a better error message
                 msg = f"Unsupported child type: {type(child)}"
                 msg += f"\n in tag {self.name}"
                 msg += f"\n child {child}"
@@ -87,24 +87,8 @@ class CaseTag(Tag):
 class Html(Tag):
     """Defines the root of an HTML document"""
 
-    def __init__(self, *children, headers: tuple | None = (), **kwargs):
-        super().__init__(*children, **kwargs)
-        self._headers = headers
-
-    @property
-    def headers(self):
-        return "".join([c.render() if isinstance(c, Tag) else c for c in self._headers])
-
     def render(self) -> str:
-        return f"""<!doctype html><html{self.attrs}><head>{self.headers}</head><body>{self.children}</body></html>"""
-
-
-class Htmx(Html):
-    def __init__(self, *children, headers: tuple | None = (), **kwargs):
-        super().__init__(*children, **kwargs)
-        self._headers = (
-            Script(src="https://cdn.jsdelivr.net/npm/htmx.org@2.0.5/dist/htmx.min.js"),
-        ) + headers  # type: ignore[operator]
+        return f"""<!doctype html><html{self.attrs}>{self.children}</html>"""
 
 
 class RawHTML(Tag):

--- a/tests/test_responses.py
+++ b/tests/test_responses.py
@@ -51,10 +51,12 @@ def test_TagResponse_html():
     @app.get("/test", response_class=air.TagResponse)
     def test_endpoint():
         return air.Html(
+            air.Head(),
+            air.Body(
             air.Main(
                 air.H1("Hello, clean HTML response!"),
                 air.P("This is a paragraph in the response."),
-            )
+            )),
         )
 
     client = TestClient(app)
@@ -73,7 +75,7 @@ def test_strings_and_tag_children():
 
     @app.get("/test", response_class=air.TagResponse)
     def test_endpoint():
-        return air.Html(air.P("This isn't a ", air.Strong("cut off"), " sentence"))
+        return air.Html(air.Body(air.P("This isn't a ", air.Strong("cut off"), " sentence")))
 
     client = TestClient(app)
     response = client.get("/test")
@@ -81,7 +83,7 @@ def test_strings_and_tag_children():
     assert response.headers["content-type"] == "text/html; charset=utf-8"
     assert (
         response.text
-        == "<!doctype html><html><head></head><body><p>This isn't a <strong>cut off</strong> sentence</p></body></html>"
+        == "<!doctype html><html><body><p>This isn't a <strong>cut off</strong> sentence</p></body></html>"
     )
 
 
@@ -140,7 +142,7 @@ def test_TagResponse_with_layout_names():
 
     @app.get("/test", response_class=CustomLayoutResponse)
     def test_endpoint():
-        return air.Main(air.H1("Hello, World!"))
+        return air.Body(air.Main(air.H1("Hello, World!")))
 
     client = TestClient(app)
     response = client.get("/test")
@@ -149,5 +151,5 @@ def test_TagResponse_with_layout_names():
     assert response.headers["content-type"] == "text/html; charset=utf-8"
     assert (
         response.text
-        == "<!doctype html><html><head></head><body><main><h1>Hello, World!</h1></main></body></html>"
+        == "<!doctype html><html><body><main><h1>Hello, World!</h1></main></body></html>"
     )

--- a/tests/test_responses.py
+++ b/tests/test_responses.py
@@ -53,10 +53,11 @@ def test_TagResponse_html():
         return air.Html(
             air.Head(),
             air.Body(
-            air.Main(
-                air.H1("Hello, clean HTML response!"),
-                air.P("This is a paragraph in the response."),
-            )),
+                air.Main(
+                    air.H1("Hello, clean HTML response!"),
+                    air.P("This is a paragraph in the response."),
+                )
+            ),
         )
 
     client = TestClient(app)
@@ -75,7 +76,9 @@ def test_strings_and_tag_children():
 
     @app.get("/test", response_class=air.TagResponse)
     def test_endpoint():
-        return air.Html(air.Body(air.P("This isn't a ", air.Strong("cut off"), " sentence")))
+        return air.Html(
+            air.Body(air.P("This isn't a ", air.Strong("cut off"), " sentence"))
+        )
 
     client = TestClient(app)
     response = client.get("/test")

--- a/tests/test_tags.py
+++ b/tests/test_tags.py
@@ -165,7 +165,6 @@ def test_pico_card():
 
 
 def test_tags_head_tag_injection():
-
     meta_tags = [
         air.Meta(property="og:title", content="Test Title"),
         air.Meta(property="og:description", content="Test Description"),
@@ -174,12 +173,15 @@ def test_tags_head_tag_injection():
     html = air.Html(
         air.Head(
             air.Title("Test Page"),
-            *meta_tags  # These should appear in <head>
+            *meta_tags,  # These should appear in <head>
         ),
         air.Body(
             air.H1("Check Page Source"),
-            air.P("The meta tags should be in the head section.")
-            ),            
-        ).render()
+            air.P("The meta tags should be in the head section."),
+        ),
+    ).render()
 
-    assert html == '<!doctype html><html><head><title>Test Page</title><meta property="og:title" content="Test Title"></meta><meta property="og:description" content="Test Description"></meta></head><body><h1>Check Page Source</h1><p>The meta tags should be in the head section.</p></body></html>'        
+    assert (
+        html
+        == '<!doctype html><html><head><title>Test Page</title><meta property="og:title" content="Test Title"></meta><meta property="og:description" content="Test Description"></meta></head><body><h1>Check Page Source</h1><p>The meta tags should be in the head section.</p></body></html>'
+    )

--- a/tests/test_tags.py
+++ b/tests/test_tags.py
@@ -84,14 +84,6 @@ def test_special_attributes():
     assert html == '<p hx-post="/get" id="53">HTMX example</p>'
 
 
-def test_htmx_render():
-    html = air.Htmx(air.P("Hello, world")).render()
-    assert (
-        html
-        == '<!doctype html><html><head><script src="https://cdn.jsdelivr.net/npm/htmx.org@2.0.5/dist/htmx.min.js"></script></head><body><p>Hello, world</p></body></html>'
-    )
-
-
 def test_raw_html_basic():
     """Test basic RawHTML rendering without escaping."""
     raw = air.RawHTML("<strong>Bold</strong> & <em>italic</em>")
@@ -170,3 +162,24 @@ def test_pico_card():
         html
         == "<article><header>Card Header</header><p>This is a card with some content.</p><footer>Card Footer</footer></article>"
     )
+
+
+def test_tags_head_tag_injection():
+
+    meta_tags = [
+        air.Meta(property="og:title", content="Test Title"),
+        air.Meta(property="og:description", content="Test Description"),
+    ]
+
+    html = air.Html(
+        air.Head(
+            air.Title("Test Page"),
+            *meta_tags  # These should appear in <head>
+        ),
+        air.Body(
+            air.H1("Check Page Source"),
+            air.P("The meta tags should be in the head section.")
+            ),            
+        ).render()
+
+    assert html == '<!doctype html><html><head><title>Test Page</title><meta property="og:title" content="Test Title"></meta><meta property="og:description" content="Test Description"></meta></head><body><h1>Check Page Source</h1><p>The meta tags should be in the head section.</p></body></html>'        


### PR DESCRIPTION
- Reduces the scope of the Html tag and removes the Htmx tag
- Doesn't address that injecting tags is a default behavior of tags, let's handle that in #69 69