### PR TITLE
Add get-only `app.page` route decorator shortcut

### DIFF
--- a/src/air/applications.py
+++ b/src/air/applications.py
@@ -309,3 +309,11 @@ class Air(FastAPI):
             deprecated=deprecated,
             **extra,
         )
+
+    def page(self, func):
+        """Decorator that creates a GET route using the function name as the path."""
+        if func.__name__ == "index":
+            route_name = "/"
+        else:
+            route_name = f"/{func.__name__}"
+        return self.get(route_name)(func)

--- a/tests/test_applications.py
+++ b/tests/test_applications.py
@@ -46,3 +46,27 @@ def test_air_plus_fastapi():
     assert response.status_code == 200
     assert response.headers["content-type"] == "text/html; charset=utf-8"
     assert response.text == "<h1>Hello, World!</h1>"
+
+
+def test_page_decorator():
+    app = air.Air()
+    page = app.page
+
+    @page
+    def index():
+        return air.H1("Home page")
+
+    @page
+    def about():
+        return air.H1("About page")
+
+    client = TestClient(app)
+    response = client.get("/")
+    assert response.status_code == 200
+    assert response.headers["content-type"] == "text/html; charset=utf-8"
+    assert response.text == "<h1>Home page</h1>"
+
+    response = client.get("/about")
+    assert response.status_code == 200
+    assert response.headers["content-type"] == "text/html; charset=utf-8"
+    assert response.text == "<h1>About page</h1>"


### PR DESCRIPTION
- Handy route shortcut
- Only works with GET requests