### PR TITLE
Form rendering

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -67,6 +67,9 @@ public/
 # Docs page
 site
 
+# Notebooks
+nbs
+
 # Caches
 .mypy_cache
 .pytest_cache

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "makefile.configureOnOpen": false
+}

--- a/docs.md
+++ b/docs.md
@@ -1,0 +1,61 @@
+
+## HTTP GET page shortcut decorator
+
+For when you want to write pages real fast.
+
+```python
+@app.page
+def dashboard():
+    return air.H1("Hello, World")
+```
+
+Using the function's name, `@app.page` maps the `dashboard` view to the `/dashboard` URL
+
+
+## Raw HTML Content
+
+For cases where you need to render raw HTML from the tag engine:
+
+```python
+from air import RawHTML
+
+# Render raw HTML content
+raw_content = RawHTML('<strong>Bold text</strong> and <em>italic</em>')
+
+# Note: RawHTML only accepts a single string argument
+# For multiple elements, combine them first:
+html_string = '<p>First</p><p>Second</p>'
+raw = RawHTML(html_string)
+```
+
+## REST + HTML without HTML in the docs
+
+For when you need FastAPI docs but without the web pages appearing in the docs:
+
+```python
+from fastapi import FastAPI
+import air
+
+# API app
+app = FastAPI()
+# HTML page app
+html = air.Air()
+
+@app.get("/api")
+async def read_root():
+    return {"Hello": "World"}
+
+
+@html.get("/")
+async def index():
+    return air.H1("Welcome to Air")
+
+# Combine into one app
+app.mount("/", html)
+```
+
+URLs to see the results:
+
+- http://127.0.0.1:8000/
+- http://127.0.0.1:8000/api
+- http://127.0.0.1:8000/docs

--- a/docs/concepts/forms.md
+++ b/docs/concepts/forms.md
@@ -1,0 +1,68 @@
+# Forms
+
+Forms, or AirForms in Air parlance, are powered by pydantic. That includes both their display and validation of data. If you have any experience with pydantic, that will go a long way towards helping your understanding of Air Forms.
+
+## A Sample Contact Form
+
+```python
+from pydantic import BaseModel, Field
+from air import AirForm
+
+class ContactModel(BaseModel):
+    name: str
+    email: str = Field(json_schema_extra={'email': True
+    })
+
+class ContactForm(AirForm):
+    model = ContactModel
+
+
+contact_form = ContactForm()
+```
+
+## Displaying a form
+
+```python
+
+contact_form.render()
+```
+
+```html
+<fieldset>
+    <label>name
+        <input name="name" type="text" id="name"></input>
+    </label>
+    <label>email
+        <input name="email" type="email" id="email"></input>
+    </label>
+</fieldset>
+```
+
+## Validation using forms
+
+```python
+# This empty dict represents a user who submitted without adding data
+empty_form = {}
+contact_form.validate(empty_form)
+```
+
+## Displaying a failed form
+
+```python
+contact_form.render()
+```
+
+```html
+<fieldset>
+    <label>
+        name
+        <input name="name" type="text" id="name" aria-invalid="true"></input>
+        <small id="name-error">Please correct this error.</small>
+    </label>
+    <label>
+        email
+        <input name="email" type="email" id="email" aria-invalid="true"></input>
+        <small id="email-error">Please correct this error.</small>
+    </label>
+</fieldset>
+```

--- a/main.py
+++ b/main.py
@@ -1,0 +1,24 @@
+from pydantic import BaseModel
+
+import air
+
+app = air.Air()
+
+
+class CheeseModel(BaseModel):
+    name: str  # type: ignore [annotation-unchecked]
+    age: int  # type: ignore [annotation-unchecked]
+
+
+class CheeseForm(air.AirForm):
+    model = CheeseModel
+
+
+@app.page
+def index():
+    cheese = CheeseForm()
+    cheese.validate({})
+
+    return air.layouts.picocss(
+        air.Body(air.Form(air.H1("Cheese Form"), cheese.render(), action="."))
+    )

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -7,6 +7,7 @@ nav:
   - Concepts:
     - concepts/index.md
     - concepts/air_tags.md
+    - concepts/forms.md
     - concepts/escaping_html.md
   - Reference:
     - api/index.md

--- a/src/air/forms.py
+++ b/src/air/forms.py
@@ -63,7 +63,7 @@ class AirForm:
     async def from_request(cls, request: Request) -> Self:
         form_data = await request.form()
         self = cls()
-        await self(form_data)
+        await self(form_data=form_data)
         return self
 
     @property

--- a/src/air/forms.py
+++ b/src/air/forms.py
@@ -111,7 +111,7 @@ def pydantic_type_to_html_type(field_info: Any) -> str:
     )
 
 
-def errors_to_dict(errors: list[dict] | None) -> list[str, dict]:
+def errors_to_dict(errors: list[dict] | None) -> dict[str, dict]:
     "Converts a pydantic error list to a dictionary for easier reference."
     if errors is None:
         return {}
@@ -146,7 +146,7 @@ def default_form_widget(
             tags.Label(
                 field_name,
                 tags.Input(name=field_name, type=input_type, id=field_name, **kwargs),
-                tags.Small("Please correct this value", id=f"{field_name}-error")
+                tags.Small("Please correct this error.", id=f"{field_name}-error")
                 if error
                 else "",
             )

--- a/src/air/forms.py
+++ b/src/air/forms.py
@@ -11,7 +11,6 @@ except ImportError:
     # NOTE: Remove once Python 3.10 support is dropped
     Self = "AirForm"  # type: ignore [assignment]
 
-
 class AirForm:
     """
     A form handler that validates incoming form data against a Pydantic model.
@@ -75,8 +74,8 @@ class AirForm:
         """
         return default_form_widget
 
-    def render(self) -> str:
-        return self.widget(model=self.model, data=self.data, errors=self.errors)
+    def render(self) -> tags.SafeStr:
+        return tags.SafeStr(self.widget(model=self.model, data=self.data, errors=self.errors))
 
 
 def pydantic_type_to_html_type(field_info: Any) -> str:

--- a/src/air/forms.py
+++ b/src/air/forms.py
@@ -80,7 +80,7 @@ class AirForm:
 
     def render(self) -> tags.SafeStr:
         return tags.SafeStr(
-            self.widget(model=self.model, data=self.data, errors=self.errors)
+            self.widget(model=self.model, data=self.initial_data, errors=self.errors)
         )
 
 
@@ -129,6 +129,14 @@ def default_form_widget(
             args = get_args(field_type)
             field_type = next((arg for arg in args if arg is not type(None)), str)
         input_type = pydantic_type_to_html_type(field_info)
-        fields.append(tags.Input(name=field_name, type=input_type, id=field_name))
+        kwargs = {}
+        # Inject values
+        if data is not None and field_name in data:
+            kwargs["value"] = data[field_name]
+        # Note that something is in error
+        # TODO
+        fields.append(
+            tags.Input(name=field_name, type=input_type, id=field_name, **kwargs)
+        )
 
     return tags.Fieldset(*fields).render()

--- a/src/air/forms.py
+++ b/src/air/forms.py
@@ -1,5 +1,8 @@
+from typing import Callable, Any, get_args
+
+from . import tags
 from fastapi import Request
-from pydantic import ValidationError
+from pydantic import ValidationError, BaseModel
 
 try:
     from typing import Self  # type: ignore [attr-defined]
@@ -33,6 +36,7 @@ class AirForm:
     data = None
     errors = None
     is_valid = None
+    action = '.'
 
     async def __call__(self, request: Request) -> Self:
         if self.model is None:
@@ -51,3 +55,56 @@ class AirForm:
         self = cls()
         await self(request)
         return self
+
+    @property
+    def widget(self) -> Callable:
+        """Widget for rendering of form in HTML
+        
+        If you want a custom widget, replace with a function that accepts:
+
+            - model: BaseModel
+            - action:str=".",
+            - data: dict|None
+            - errors:dict|None=None
+        """
+        return default_form_widget
+    
+    def render(self) -> str:
+        return self.widget(model=self.model, action=self.action,data=self.data, errors=self.errors)
+    
+def pydantic_type_to_html_type(field_type: Any):
+    """Return HTML type from pydantic type.
+    
+    Default to 'text' for unknown types.
+    """
+    return {
+        int: 'number',
+        float: 'number',
+        bool: 'checkbox',
+        str: 'text'
+    }.get(field_type, 'text')
+
+
+
+def default_form_widget(model: type[BaseModel], action:str=".",
+                        data: dict|None=None, errors:dict|None=None) -> str:
+    # TODO add looping through data and associated with any errors
+    # Make individual inputs their own widget?
+    fields = []
+    for field_name, field_info in model.model_fields.items():
+        field_type = field_info.annotation
+        
+        # Handle optional types (Union with None)
+        if hasattr(field_type, '__origin__') and field_type.__origin__ is type(None | str).__origin__:
+            # This is a Union type, get the non-None type
+            args = get_args(field_type)
+            field_type = next((arg for arg in args if arg is not type(None)), str)        
+        input_type = pydantic_type_to_html_type(field_type)
+        fields.append(
+            tags.Input(name=field_name, type=input_type, id=field_name)
+        )
+    fields.append(tags.Button('Submit', type='submit'))
+
+    return tags.Form(
+            *fields,
+            action=action).render()

--- a/src/air/tags.py
+++ b/src/air/tags.py
@@ -4,6 +4,20 @@ import html
 from functools import cached_property
 
 
+class SafeStr(str):
+    """A strtring subclass that doesn't trigger html.escape() when called by Tag.render()
+    
+        Example:
+            sample = SafeStr('Hello, world')
+    """
+    def __new__(cls, value):
+        obj = super().__new__(cls, value)
+        return obj
+
+    def __repr__(self):
+        return super().__repr__()
+
+
 def clean_html_attr_key(key: str) -> str:
     """Clean up HTML attribute keys to match the standard W3C HTML spec.
 
@@ -49,6 +63,8 @@ class Tag:
         for child in self._children:
             if isinstance(child, Tag):
                 elements.append(child.render())
+            elif isinstance(child, SafeStr):
+                elements.append(child)
             elif isinstance(child, str):
                 elements.append(html.escape(child))
             elif isinstance(child, int):

--- a/src/air/tags.py
+++ b/src/air/tags.py
@@ -4,21 +4,6 @@ import html
 from functools import cached_property
 
 
-class SafeStr(str):
-    """A strtring subclass that doesn't trigger html.escape() when called by Tag.render()
-
-    Example:
-        sample = SafeStr('Hello, world')
-    """
-
-    def __new__(cls, value):
-        obj = super().__new__(cls, value)
-        return obj
-
-    def __repr__(self):
-        return super().__repr__()
-
-
 def clean_html_attr_key(key: str) -> str:
     """Clean up HTML attribute keys to match the standard W3C HTML spec.
 
@@ -89,6 +74,24 @@ class CaseTag(Tag):
     @property
     def name(self) -> str:
         return self._name[0].lower() + self._name[1:]
+
+
+# Utilities
+
+
+class SafeStr(str):
+    """A string subclass that doesn't trigger html.escape() when called by Tag.render()
+
+    Example:
+        sample = SafeStr('Hello, world')
+    """
+
+    def __new__(cls, value):
+        obj = super().__new__(cls, value)
+        return obj
+
+    def __repr__(self):
+        return super().__repr__()
 
 
 # Special tags

--- a/src/air/tags.py
+++ b/src/air/tags.py
@@ -6,10 +6,11 @@ from functools import cached_property
 
 class SafeStr(str):
     """A strtring subclass that doesn't trigger html.escape() when called by Tag.render()
-    
-        Example:
-            sample = SafeStr('Hello, world')
+
+    Example:
+        sample = SafeStr('Hello, world')
     """
+
     def __new__(cls, value):
         obj = super().__new__(cls, value)
         return obj

--- a/tests/test_forms.py
+++ b/tests/test_forms.py
@@ -2,7 +2,7 @@ from typing import Annotated
 
 from fastapi import Depends, Request
 from fastapi.testclient import TestClient
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 import air
 
@@ -177,3 +177,18 @@ def test_form_render_with_errors():
         html
         == '<fieldset><label>name<input name="name" type="text" id="name" aria-invalid="true"></input><small id="name-error">Please correct this error.</small></label><label>age<input name="age" type="number" id="age" aria-invalid="true"></input><small id="age-error">Please correct this error.</small></label></fieldset>'
     )
+
+
+def test_html_input_field_types():
+    class ContactModel(BaseModel):
+        name: str
+        email: str = Field(json_schema_extra={"email": True})
+        date_and_time: str = Field(json_schema_extra={"datedatetime-local": True})
+
+    class ContactForm(air.AirForm):
+        model = ContactModel
+
+    contact_form = ContactForm()
+    html = contact_form.render()
+    assert 'type="datedatetime-local"' in html
+    assert 'type="email"' in html

--- a/tests/test_forms.py
+++ b/tests/test_forms.py
@@ -68,3 +68,24 @@ def test_form_validation_in_view():
     assert response.status_code == 200
     assert response.headers["content-type"] == "text/html; charset=utf-8"
     assert response.text == "<!doctype html><html><h1>2</h1></html>"
+
+
+def test_form_render():
+    class CheeseModel(BaseModel):
+        name: str  # type: ignore [annotation-unchecked]
+        age: int  # type: ignore [annotation-unchecked]    
+
+    class CheeseForm(air.AirForm):
+        model = CheeseModel
+
+    app = air.Air()
+
+    @app.post("/cheese")
+    async def cheese_form(request: Request):
+        cheese = await CheeseForm.validate(request)
+        return cheese.render()
+    
+    client = TestClient(app)
+    response = client.post("/cheese", data={"name": "cheddar", "age": 5})
+     
+    assert response.text == ''

--- a/tests/test_forms.py
+++ b/tests/test_forms.py
@@ -110,6 +110,22 @@ def test_form_render():
     )
 
 
+def test_form_render_with_values():
+    class CheeseModel(BaseModel):
+        name: str  # type: ignore [annotation-unchecked]
+        age: int  # type: ignore [annotation-unchecked]
+
+    class CheeseForm(air.AirForm):
+        model = CheeseModel
+
+    cheese = CheeseForm(form_data=dict(name="Cheddar", age=3))
+
+    assert (
+        cheese.render()
+        == '<fieldset><input name="name" type="text" id="name" value="Cheddar"></input><input name="age" type="number" id="age" value="3"></input></fieldset>'
+    )
+
+
 def test_form_render_in_view():
     class CheeseModel(BaseModel):
         name: str  # type: ignore [annotation-unchecked]

--- a/tests/test_forms.py
+++ b/tests/test_forms.py
@@ -162,9 +162,18 @@ def test_form_render_with_errors():
         model = CheeseModel
 
     cheese = CheeseForm()
+
+    # render without validation
+    html = cheese.render()
+    assert "Please correct this error." not in html
+
+    # render with validation
     cheese.validate({})
+    html = cheese.render()
+
+    assert "Please correct this error." in html
 
     assert (
-        cheese.render()
-        == '<fieldset><label>name<input name="name" type="text" id="name" aria-invalid="true"></input><small id="name-error">Please correct this value</small></label><label>age<input name="age" type="number" id="age" aria-invalid="true"></input><small id="age-error">Please correct this value</small></label></fieldset>'
+        html
+        == '<fieldset><label>name<input name="name" type="text" id="name" aria-invalid="true"></input><small id="name-error">Please correct this error.</small></label><label>age<input name="age" type="number" id="age" aria-invalid="true"></input><small id="age-error">Please correct this error.</small></label></fieldset>'
     )

--- a/tests/test_forms.py
+++ b/tests/test_forms.py
@@ -106,7 +106,7 @@ def test_form_render():
 
     assert (
         cheese.render()
-        == '<fieldset><input name="name" type="text" id="name"></input><input name="age" type="number" id="age"></input></fieldset>'
+        == '<fieldset><label>name<input name="name" type="text" id="name"></input></label><label>age<input name="age" type="number" id="age"></input></label></fieldset>'
     )
 
 
@@ -118,11 +118,11 @@ def test_form_render_with_values():
     class CheeseForm(air.AirForm):
         model = CheeseModel
 
-    cheese = CheeseForm(form_data=dict(name="Cheddar", age=3))
+    cheese = CheeseForm(dict(name="Cheddar", age=3))
 
     assert (
         cheese.render()
-        == '<fieldset><input name="name" type="text" id="name" value="Cheddar"></input><input name="age" type="number" id="age" value="3"></input></fieldset>'
+        == '<fieldset><label>name<input name="name" type="text" id="name" value="Cheddar"></input></label><label>age<input name="age" type="number" id="age" value="3"></input></label></fieldset>'
     )
 
 
@@ -149,5 +149,22 @@ def test_form_render_in_view():
     assert response.headers["content-type"] == "text/html; charset=utf-8"
     assert (
         response.text
-        == '<form><fieldset><input name="name" type="text" id="name"></input><input name="age" type="number" id="age"></input></fieldset></form>'
+        == '<form><fieldset><label>name<input name="name" type="text" id="name"></input></label><label>age<input name="age" type="number" id="age"></input></label></fieldset></form>'
+    )
+
+
+def test_form_render_with_errors():
+    class CheeseModel(BaseModel):
+        name: str  # type: ignore [annotation-unchecked]
+        age: int  # type: ignore [annotation-unchecked]
+
+    class CheeseForm(air.AirForm):
+        model = CheeseModel
+
+    cheese = CheeseForm()
+    cheese.validate({})
+
+    assert (
+        cheese.render()
+        == '<fieldset><label>name<input name="name" type="text" id="name" aria-invalid="true"></input><small id="name-error">Please correct this value</small></label><label>age<input name="age" type="number" id="age" aria-invalid="true"></input><small id="age-error">Please correct this value</small></label></fieldset>'
     )

--- a/tests/test_forms.py
+++ b/tests/test_forms.py
@@ -101,3 +101,27 @@ def test_form_render():
         == '<fieldset><input name="name" type="text" id="name"></input><input name="age" type="number" id="age"></input></fieldset>'
     )
 
+def test_form_render_in_view():
+    class CheeseModel(BaseModel):
+        name: str  # type: ignore [annotation-unchecked]
+        age: int  # type: ignore [annotation-unchecked]
+
+    class CheeseForm(air.AirForm):
+        model = CheeseModel
+
+    cheese = CheeseForm()
+
+    app = air.Air()
+
+    @app.post("/cheese")
+    async def cheese_form(request: Request):
+        cheese = CheeseForm()
+        return air.Form(cheese.render())
+
+    client = TestClient(app)
+
+    # Test with valid form data
+    response = client.post("/cheese", data={"name": "cheddar", "age": 5})
+    assert response.status_code == 200
+    assert response.headers["content-type"] == "text/html; charset=utf-8"
+    assert response.text == ""

--- a/tests/test_forms.py
+++ b/tests/test_forms.py
@@ -124,4 +124,4 @@ def test_form_render_in_view():
     response = client.post("/cheese", data={"name": "cheddar", "age": 5})
     assert response.status_code == 200
     assert response.headers["content-type"] == "text/html; charset=utf-8"
-    assert response.text == ""
+    assert response.text == '<form><fieldset><input name="name" type="text" id="name"></input><input name="age" type="number" id="age"></input></fieldset></form>'

--- a/tests/test_forms.py
+++ b/tests/test_forms.py
@@ -2,7 +2,7 @@ from typing import Annotated
 
 from fastapi import Depends, Request
 from fastapi.testclient import TestClient
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 import air
 
@@ -72,8 +72,9 @@ def test_form_validation_in_view():
 
 def test_form_render():
     class CheeseModel(BaseModel):
-        name: str  # type: ignore [annotation-unchecked]
-        age: int  # type: ignore [annotation-unchecked]    
+        id: int = Field(json_schema_extra=dict(hidden=True))
+        name: str  
+        age: int
 
     class CheeseForm(air.AirForm):
         model = CheeseModel
@@ -88,4 +89,4 @@ def test_form_render():
     client = TestClient(app)
     response = client.post("/cheese", data={"name": "cheddar", "age": 5})
      
-    assert response.text == ''
+    assert response.text == '<fieldset><input name="id" type="hidden" id="id"></input><input name="name" type="text" id="name"></input><input name="age" type="number" id="age"></input></fieldset>'

--- a/tests/test_forms.py
+++ b/tests/test_forms.py
@@ -181,9 +181,9 @@ def test_form_render_with_errors():
 
 def test_html_input_field_types():
     class ContactModel(BaseModel):
-        name: str
-        email: str = Field(json_schema_extra={"email": True})
-        date_and_time: str = Field(json_schema_extra={"datedatetime-local": True})
+        name: str  # type: ignore [annotation-unchecked]
+        email: str = Field(json_schema_extra={"email": True})  # type: ignore [annotation-unchecked]
+        date_and_time: str = Field(json_schema_extra={"datedatetime-local": True})  # type: ignore [annotation-unchecked]
 
     class ContactForm(air.AirForm):
         model = ContactModel

--- a/tst.html
+++ b/tst.html
@@ -1,0 +1,1 @@
+<!doctype html><html><head><link rel="stylesheet" href="https://unpkg.com/mvp.css"></link><script src="https://cdn.jsdelivr.net/npm/htmx.org@2.0.6/dist/htmx.min.js" integrity="sha384-Akqfrbj/HpNVo8k11SXBb6TlBWmXXlYQrCSqEWmyKJe+hDm3Z/B2WVG4smwBkRVm" crossorigin="anonymous"></script><title>Cheese Monger</title></head><body><main><h1>Cheese Monger</h1></main></body></html>


### PR DESCRIPTION
For #82

- [x] render basic form
- [x] handle hidden inputs and other types
- [x] Inject values
- [x] Mark errors
- [x] Render without escaping in views
- [x] Document usage
- [x] Follow-up ticket: Show type of failure rather than just that an error happened. Done as #122 
- [x] Follow-up ticket: Create `AirField` wrapper of `pydantic.Field` which makes adding of special input types, label, and other things cleaner. Done as #123 
