### PR TITLE
Add boolean attributes to Air Tags plus improve docs

### DIFF
--- a/docs/concepts/air_tags.md
+++ b/docs/concepts/air_tags.md
@@ -1,16 +1,12 @@
 # Air Tags
 
-Tags, also known as "Air Tags", are a fast, expressive way to generate HTML. Instead of a template language, Air Tags use Python classes to represent HTML elements. This allows leveraging Python's capabilities to generate content.
+**Air Tags**, sometimes shortend to **Tags**, are Python classes that render HTML. They can be combined to render web pages or small components. **Air Tags** are typed and documented, working well with any code completion tool.
 
 !!! note
 
-    This document covers how Tags, or Air Tags work. The full reference for them is the [Tag API Reference](../api/tags.md).
+    This document covers how **Air Tags** work. The full reference for them is the [Tag API Reference](../api/tags.md).
 
-## What are Air Tags?
-
-**Air Tags** are Python classes that render HTML. They can be combined to render web pages or small components. Air Tags are typed and documented, working well with any code completion tool.
-
-## How Air Tags work
+## How **Air Tags** work
 
 Used individually or combined into a greater whole, every Air Tag includes a `render()` method. When the render method is called, it returns the HTML representation of the Air Tag, as well as all the children of the Air Tag.
 
@@ -37,6 +33,104 @@ This is the output of the `render()` method for the example above:
 </article>
 ```
 
+## Attributes
+
+**Air Tags** convert keyword arguments into attributes. So:
+
+```python+html
+air.P('Hello', id="mine")
+```
+
+renders as:
+
+```html
+<p id="mine">Hello</p>
+```
+
+Lets take a look at some additional scenarios.
+
+### Setting the `class` attribute
+
+In Python `class` is a protected word. To set the `class` attribute in **Air Tags**, use the `class_` keyword.
+
+```python
+air.P('Hello', class_='plain')
+```
+
+renders as
+
+```html
+<p class="plain">Hello</p>
+```
+
+### Setting the `for` attribute
+
+In Python `for` is a protected word. To set the `for` attribute in **Air Tags**, use the `for_` keyword.
+
+```python
+air.Label(
+    'Email',
+    air.Input(name='email', type='email')
+    for_='email'
+)
+```
+
+renders as
+
+```html
+<label for="email">
+    Email
+    <input name="email" type="email" />
+</label>
+```
+
+### Attributes starting with special characters
+
+To get around that in Python we can't begin function arguments with special characters, we lean into how **Air Tags** is kwargs friendly.
+
+```python
+air.P('Hello', class_='plain', **{'@data': 6})
+```
+
+Renders as:
+
+```html
+<p class="plain" @data="6">Hello</p>
+```
+
+
+### Single word attributes
+
+To set or hide single word attributes like `@selected`, set the tag to `True` or `False` respectively. 
+
+```python
+air.Select(
+    air.Option('South America', value='SA', selected=True),
+    air.Option('North America', value='NA', selected=False)
+)
+```
+
+Renders as:
+
+```html
+<select>
+    <option value="SA" selected>South America</option>
+    <option value="NA">North America</option>
+</select>
+```
+
+If you need an value set to `true`, use `"true"` in Python. For example:
+
+```python
+air.P("Air makes FastAPI web pages easy", draggable="true")
+```
+
+Renders as:
+
+```html
+<p draggable="true">Air makes FastAPI web pages easy</p>
+```
+
 ## Works well with SVGs
 
 Unlike HTML, SVG tags are case-sensitive. You can access SVG tags by importing them from the `air.svg` module. Here's a simple example:
@@ -61,7 +155,7 @@ This will render the following SVG:
 
 ## Custom Air Tags
 
-The best way to define your own Air Tags is to subclass the `air.Tag` class. Here's a simple example:
+The best way to define your own **Air Tags** is to subclass the `air.Tag` class. Here's a simple example:
 
 
 ```python
@@ -83,7 +177,7 @@ This will produce the following HTML:
 <awesome class="desert">Ice Cream</awesome>
 ```
 
-## Functions as Custom Air Tags 
+## Functions as Custom **Air Tags** 
 
 Subclasses are not the only way to create custom Air Tags. You can also use functions to create Air Tags. This is particularly useful for putting together components quickly without needing to define a class. Here's an example of a function that creates a custom Air Tag for a [picocss card](https://picocss.com/docs/card):
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -77,4 +77,3 @@ omit = [
 
 [tool.uv]
 package = true
-

--- a/src/air/tags.py
+++ b/src/air/tags.py
@@ -84,9 +84,17 @@ class Tag:
     def attrs(self) -> str:
         if not self._attrs:
             return ""
-        return " " + " ".join(
-            f'{clean_html_attr_key(k)}="{v}"' for k, v in self._attrs.items()
-        )
+        attrs = []
+        for k, v in self._attrs.items():
+            if isinstance(v, bool) and v is True:
+                # Add single word attribute like "selected"
+                attrs.append(k)
+            elif isinstance(v, bool) and v is False:
+                # Skip single word attribute like "selected"
+                continue
+            else:
+                attrs.append(f'{clean_html_attr_key(k)}="{v}"')
+        return " " + " ".join(attrs)
 
     @cached_property
     def children(self):
@@ -230,7 +238,7 @@ html_attributes = {
         "media",
         "ping",
         "class_",
-        "id_",
+        "id",
     ]
 }
 
@@ -263,7 +271,7 @@ class A(Tag):
         media: str | None = None,
         ping: str | None = None,
         class_: str | None = None,
-        id_: str | None = None,
+        id: str | None = None,
         **kwargs,
     ):
         super().__init__(*children, **kwargs | locals_cleanup(locals(), self))

--- a/tests/test_tags.py
+++ b/tests/test_tags.py
@@ -1,6 +1,11 @@
 import air
 
 
+def _r(tag):
+    "Shortcut for easy renders"
+    return tag.render()
+
+
 def test_atag_no_attrs_no_children():
     assert air.A().render() == "<a></a>"
 
@@ -252,4 +257,20 @@ air.Form(
 
 def test_tags_support_global_attributes():
     assert air.A("Hello", data=123).render() == '<a data="123">Hello</a>'
-    assert air.A("this", draggable=True).render() == '<a draggable="True">this</a>'
+    assert air.A("this", draggable="true").render() == '<a draggable="true">this</a>'
+
+
+def test_special_characters():
+    assert air.P("Hello", id="mine").render() == '<p id="mine">Hello</p>'
+    assert air.P("Hello", **{"@data": 1}).render() == '<p @data="1">Hello</p>'
+
+
+def test_bool_attributes():
+    assert (
+        _r(air.Option("South America", value="SA", selected=True))
+        == '<option value="SA" selected>South America</option>'
+    )
+    assert (
+        _r(air.Option("North America", value="NA", selected=False))
+        == '<option value="NA">North America</option>'
+    )


### PR DESCRIPTION
- Added boolean attributes to Air Tags (ex. selected=True renders as selected) Fixes #150 
- Change the `id_` HTML attribute signature to just `id`
- Document special cases for tags