### PR TITLE
Remove the HTML to Air Tag utility

### DIFF
--- a/docs/api/tags/index.md
+++ b/docs/api/tags/index.md
@@ -30,4 +30,3 @@ What remains on this page are core **Air Tag** that either have great utility (*
         - CaseTag
         - NoEscapeTag
         - SafeStr
-        - html_to_airtags

--- a/docs/concepts/air_tags.md
+++ b/docs/concepts/air_tags.md
@@ -305,3 +305,6 @@ This will generate HTML that looks something like this, without any wrapping tex
      >Cart 2</a>
 ```
 
+## Converting HTML to Air Tags
+
+The easiest way to do that is with the [air-convert](https://pypi.org/project/air-convert/) package. 

--- a/src/air/__init__.py
+++ b/src/air/__init__.py
@@ -355,6 +355,5 @@ from .tags import (
 from .tags import (
     Wbr as Wbr,
 )
-from .tags import html_to_airtags as html_to_airtags
 from .templates import JinjaRenderer as JinjaRenderer
 from .templates import Jinja2Renderer as Jinja2Renderer

--- a/src/air/tags.py
+++ b/src/air/tags.py
@@ -3,51 +3,6 @@
 import html
 from functools import cached_property
 from typing import Any
-from xml.etree import ElementTree as ET
-
-
-def html_to_airtags(html_text: str, air_prefix: bool = True) -> str:
-    def convert_attrs(attrs):
-        parts = []
-        for key, value in attrs.items():
-            if key in {"class", "for", "id_"}:
-                key += "_"
-            parts.append(f"{key}='{html.escape(value, quote=True)}'")
-        return parts
-
-    def convert_node(el, indent=0, air_prefix: bool = True):
-        ind = "    " * indent
-        if air_prefix:
-            tag = f"air.{el.tag.capitalize()}"
-        else:
-            tag = el.tag.capitalize()
-
-        args = []
-        # Add text before children if any
-        if el.text and el.text.strip():
-            args.append(repr(el.text.strip()))
-
-        # Add children recursively
-        for child in el:
-            args.append(convert_node(child, indent + 1, air_prefix=air_prefix))
-            if child.tail and child.tail.strip():
-                args.append(repr(child.tail.strip()))
-
-        # Add attributes
-        attr_args = convert_attrs(el.attrib)
-        all_args = args + attr_args
-
-        if all_args:
-            if len(all_args) == 1:
-                return f"{ind}{tag}(\n{all_args[0]})\n"
-            else:
-                joined = ",\n".join("    " * (indent + 1) + arg for arg in all_args)
-                return f"{ind}{tag}(\n{joined}\n{ind})"
-        else:
-            return f"{ind}{tag}()"
-
-    root = ET.fromstring(html_text)
-    return convert_node(root, air_prefix=air_prefix)
 
 
 def clean_html_attr_key(key: str) -> str:

--- a/tests/test_tags.py
+++ b/tests/test_tags.py
@@ -210,52 +210,6 @@ def test_style_tag():
     assert html == f"""<style class="test">{css}</style>"""
 
 
-def test_html_to_tags():
-    sample = """
-    <html>
-        <body>
-            <main>
-                <h1 class="header">Hello, World</h1>
-            </main>
-        </body>
-    </html>"""
-    assert "air.H1" in air.html_to_airtags(sample)
-    assert "H1" in air.html_to_airtags(sample)
-
-    # Now test with no prefix
-    assert "air.H1" not in air.html_to_airtags(sample, air_prefix=False)
-    assert "H1" in air.html_to_airtags(sample, air_prefix=False)
-
-
-def test_html_to_tags_multi_attrs():
-    sample = """
-    <form action="." method="post" class="searcho">
-        <label for="search">
-        Search:
-        <input type="search" name="search" />
-        </label>
-    </form>
-"""
-    assert (
-        air.html_to_airtags(sample)
-        == """
-air.Form(
-        air.Label(
-        'Search:',
-                air.Input(
-            type='search',
-            name='search'
-        ),
-        for_='search'
-    ),
-    action='.',
-    method='post',
-    class_='searcho'
-)
-""".strip()
-    )
-
-
 def test_tags_support_global_attributes():
     assert air.A("Hello", data=123).render() == '<a data="123">Hello</a>'
     assert air.A("this", draggable="true").render() == '<a draggable="true">this</a>'


### PR DESCRIPTION
For licensing reasons this functionality has been moved to the https://pypi.org/project/air-convert/ project.