### PR TITLE
Readme improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ For `uv` users, just create a virtualenv and install the air package, like:
 uv venv
 source .venv/bin/activate
 uv add air
-uv add fastapi[standard]
+uv add "fastapi[standard]"
 ```
 
 ## A Simple Example
@@ -73,8 +73,17 @@ async def index():
     return air.Html(air.H1("Hello, world!", style="color: blue;"))
 ```
 
+Run the app with:
+
+```sh
+fastapi dev
+```
+
 > [!NOTE]
 > This example uses Air Tags, which are Python classes that render as HTML. Air Tags are typed and documented, designed to work well with any code completion tool.
+> You can also run this with `uv run uvicorn main:app --reload` if you prefer using Uvicorn directly.
+
+Then open your browser to <http://127.0.0.1:8000> to see the result.
 
 ## Combining FastAPI and Air
 
@@ -112,6 +121,7 @@ Want to use Jinja2 instead of Air Tags? We've got you covered.
 
 ```python
 import air
+from air.requests import Request
 from fastapi import FastAPI
 
 app = air.Air()


### PR DESCRIPTION
This pull request updates the `README.md` to improve clarity and usability for getting started with Air and FastAPI. The most important changes include clarifying installation instructions, adding explicit commands for running the app, and updating example code to include necessary imports.

**Installation and usage instructions:**

* Clarified the installation command for FastAPI by quoting the package name in `uv add "fastapi[standard]"` to prevent shell parsing issues.
* Added instructions for running the app with `fastapi dev`, and noted the alternative `uv run uvicorn main:app --reload` for users who prefer Uvicorn directly.
* Provided guidance to open the browser at <http://127.0.0.1:8000> to view the running app.

**Example code improvements:**

* Added `from air.requests import Request` to the Jinja2 example to ensure all necessary imports are present for users copying the example code.