### PR TITLE
BUG: SSEResponse now Handles str and Tag types, with linebreaks handled cleanly

### DIFF
--- a/src/air/responses.py
+++ b/src/air/responses.py
@@ -83,7 +83,10 @@ class SSEResponse(StreamingResponse):
         async def lottery_generator():
             while True:
                 lottery_numbers = ", ".join([str(random.randint(1, 40)) for x in range(6)])
+                # Tags work seamlessly
                 yield air.Aside(lottery_numbers)
+                # As do strings. Non-strings are cast to strings via the str built-in
+                yieled "Hello\nworld"
                 await sleep(1)
 
 

--- a/src/air/tags.py
+++ b/src/air/tags.py
@@ -89,17 +89,6 @@ class Tag:
             return f"<{self.name}{self.attrs} />"
         return f"<{self.name}{self.attrs}>{self.children}</{self.name}>"
 
-    def encode(self, charset: str = "utf-8") -> bytes:
-        """Renders the Tag for use in SSEResponse to support server sent responses.
-
-        As the Tag is intended to be called from within a generator, this logic needs
-        to be defined here in the base Tag class.
-        """
-        lines = [t for t in self.render().splitlines()]
-        formatted = [f"data: {t}" for t in lines]
-        data = "\n".join(formatted)
-        return f"event: message\n{data}\n\n".encode(charset)
-
 
 class CaseTag(Tag):
     """This is for case-sensitive tags like those used in SVG generation."""

--- a/tests/test_responses.py
+++ b/tests/test_responses.py
@@ -1,6 +1,5 @@
 from typing import Any
 
-from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
 import air
@@ -8,7 +7,7 @@ import air
 
 def test_TagResponse_obj():
     """Test the TagResponse class."""
-    app = FastAPI()
+    app = air.Air()
 
     @app.get("/test")
     def test_endpoint():
@@ -25,7 +24,7 @@ def test_TagResponse_obj():
 def test_TagResponse_type():
     """Test the TagResponse class."""
 
-    app = FastAPI()
+    app = air.Air()
 
     @app.get("/test", response_class=air.TagResponse)
     def test_endpoint():
@@ -48,7 +47,7 @@ def test_TagResponse_type():
 def test_TagResponse_html():
     """Test the TagResponse class."""
 
-    app = FastAPI()
+    app = air.Air()
 
     @app.get("/test", response_class=air.TagResponse)
     def test_endpoint():
@@ -74,7 +73,7 @@ def test_TagResponse_html():
 
 
 def test_strings_and_tag_children():
-    app = FastAPI()
+    app = air.Air()
 
     @app.get("/test", response_class=air.TagResponse)
     def test_endpoint():
@@ -93,7 +92,7 @@ def test_strings_and_tag_children():
 
 
 def test_custom_name_in_response():
-    app = FastAPI()
+    app = air.Air()
 
     def Card(sentence):
         return air.Article(air.Header("Header"), sentence, air.Footer("Footer"))
@@ -120,7 +119,7 @@ def test_TagResponse_with_layout_strings():
                 "utf-8"
             )
 
-    app = FastAPI()
+    app = air.Air()
 
     @app.get("/test", response_class=CustomLayoutResponse)
     def test_endpoint():
@@ -143,7 +142,7 @@ def test_TagResponse_with_layout_names():
             content = super().render(content).decode("utf-8")
             return air.Html(air.Raw(content)).render().encode("utf-8")
 
-    app = FastAPI()
+    app = air.Air()
 
     @app.get("/test", response_class=CustomLayoutResponse)
     def test_endpoint():
@@ -162,7 +161,7 @@ def test_TagResponse_with_layout_names():
 
 def test_AirResponse():
     """Test the AirResponse class."""
-    app = FastAPI()
+    app = air.Air()
 
     @app.get("/test_tag", response_class=air.AirResponse)
     def test_tag_endpoint():
@@ -188,7 +187,7 @@ def test_AirResponse():
 
 def test_SSEResponse():
     """Test the SSEResponse class."""
-    app = FastAPI()
+    app = air.Air()
 
     async def event_generator():
         yield air.P("Hello")
@@ -206,4 +205,49 @@ def test_SSEResponse():
     assert (
         response.text
         == "event: message\ndata: <p>Hello</p>\n\nevent: message\ndata: <p>World</p>\n\n"
+    )
+
+
+def test_SSEResponse_multiline_tag_content():
+    """Test the SSEResponse class."""
+    app = air.Air()
+
+    async def event_generator():
+        yield air.P("Hello\nWorld")
+        yield air.P("World\nHello")
+
+    @app.get("/test")
+    async def test_endpoint():
+        return air.SSEResponse(event_generator())
+
+    client = TestClient(app)
+    response = client.get("/test")
+
+    assert response.status_code == 200
+    assert response.headers["content-type"] == "text/event-stream; charset=utf-8"
+    assert (
+        response.text
+        == "event: message\ndata: <p>Hello\ndata: World</p>\n\nevent: message\ndata: <p>World\ndata: Hello</p>\n\n"
+    )
+
+
+def test_SSEResponse_string_content():
+    app = air.Air()
+
+    async def event_generator():
+        yield "Hello\nWorld"
+        yield "Air is cool\nTry it out!"
+
+    @app.get("/test")
+    async def test_endpoint():
+        return air.SSEResponse(event_generator())
+
+    client = TestClient(app)
+    response = client.get("/test")
+
+    assert response.status_code == 200
+    assert response.headers["content-type"] == "text/event-stream; charset=utf-8"
+    assert (
+        response.text
+        == "event: message\ndata: Hello\ndata: World\n\nevent: message\ndata: Air is cool\ndata: Try it out!\n\n"
     )

--- a/tests/test_tags.py
+++ b/tests/test_tags.py
@@ -269,6 +269,6 @@ def test_tag_for_tag_subclass_wrapper():
     assert html == "<p>Hello, world!</p>"
 
 
-def test_format_sse_message_from_tag():
-    tag = air.P("I am a paragraph")
-    assert tag.encode("utf-8") == b"event: message\ndata: <p>I am a paragraph</p>\n\n"
+# def test_format_sse_message_from_tag():
+#     tag = air.P("I am a paragraph")
+#     assert tag.encode("utf-8") == b"event: message\ndata: <p>I am a paragraph</p>\n\n"


### PR DESCRIPTION
For #253 

This pull request refactors how Server-Sent Events (SSE) responses are generated and handled in the `air` framework, particularly focusing on the `SSEResponse` class. The main improvements include centralizing and simplifying the logic for formatting SSE messages, enhancing support for both tag and string content, and updating tests to use the `air.Air` app class instead of `FastAPI`. The changes also add more robust test coverage for multiline content in SSE responses.

**SSEResponse and SSE message formatting:**

* Refactored the SSE message formatting logic from the `Tag.encode()` method into the new `SSEResponse.stream_response()` method, allowing both `Tag` instances and plain strings to be streamed as SSE messages, including support for multiline content. (`src/air/responses.py` [[1]](diffhunk://#diff-26724604fdd37541c84811f830405aca4aa2401c420100b4a6cbb53cc5deef42R99-R122) [[2]](diffhunk://#diff-e14fd0d1e563b32e21626eaeba650c79ce24651dfe03c83a5d977372384ff8ecL92-L102)
* Updated the example in the `SSEResponse` docstring to clarify usage with tags and strings. (`src/air/responses.py` [[1]](diffhunk://#diff-26724604fdd37541c84811f830405aca4aa2401c420100b4a6cbb53cc5deef42R59) [[2]](diffhunk://#diff-26724604fdd37541c84811f830405aca4aa2401c420100b4a6cbb53cc5deef42R86-R89)

**Testing improvements:**

* Updated all tests to use `air.Air` instead of `FastAPI` for app instantiation, ensuring consistency with the framework's intended usage. (`tests/test_responses.py` [[1]](diffhunk://#diff-f3bc3ab9bfe202a2ded4890229180e22f76181ae47ab29df2b8b4ccec7e5d293L3-R10) [[2]](diffhunk://#diff-f3bc3ab9bfe202a2ded4890229180e22f76181ae47ab29df2b8b4ccec7e5d293L28-R27) [[3]](diffhunk://#diff-f3bc3ab9bfe202a2ded4890229180e22f76181ae47ab29df2b8b4ccec7e5d293L51-R50) [[4]](diffhunk://#diff-f3bc3ab9bfe202a2ded4890229180e22f76181ae47ab29df2b8b4ccec7e5d293L77-R76) [[5]](diffhunk://#diff-f3bc3ab9bfe202a2ded4890229180e22f76181ae47ab29df2b8b4ccec7e5d293L96-R95) [[6]](diffhunk://#diff-f3bc3ab9bfe202a2ded4890229180e22f76181ae47ab29df2b8b4ccec7e5d293L123-R122) [[7]](diffhunk://#diff-f3bc3ab9bfe202a2ded4890229180e22f76181ae47ab29df2b8b4ccec7e5d293L146-R145) [[8]](diffhunk://#diff-f3bc3ab9bfe202a2ded4890229180e22f76181ae47ab29df2b8b4ccec7e5d293L165-R164) [[9]](diffhunk://#diff-f3bc3ab9bfe202a2ded4890229180e22f76181ae47ab29df2b8b4ccec7e5d293L191-R190)
* Added new tests to verify correct SSE output for multiline tag content and plain string content, improving coverage for edge cases in SSE streaming. (`tests/test_responses.py` [tests/test_responses.pyR209-R253](diffhunk://#diff-f3bc3ab9bfe202a2ded4890229180e22f76181ae47ab29df2b8b4ccec7e5d293R209-R253))
* Removed the obsolete test for `Tag.encode()` since SSE formatting is now handled by `SSEResponse`. (`tests/test_tags.py` [tests/test_tags.pyL272-R274](diffhunk://#diff-c2a8158c2ea75e325dc5d418fe408374d215b771f40be4a907dca380ad4a6701L272-R274))

- [x] Tests added
- [x] Implementation documented in docstring of class
- [x] Documentation ticket added (#27)