### PR TITLE
Feat pyproject.toml - All - Draft

### DIFF
--- a/justfile
+++ b/justfile
@@ -2,7 +2,6 @@
 qa:
     uv run --python=3.13 --extra test ruff format .
     uv run --python=3.13 --extra test ruff check . --fix
-    uv run --python=3.13 --extra test ruff check --select I --fix .
     uv run --python=3.13 --extra test ty check .
     uv run --python=3.13 --extra test pytest .
 

--- a/justfile
+++ b/justfile
@@ -3,7 +3,7 @@ qa:
     uv run --python=3.13 --extra test ruff format .
     uv run --python=3.13 --extra test ruff check . --fix
     uv run --python=3.13 --extra test ty check .
-    uv run --python=3.13 --extra test pytest .
+    uv run --python=3.13 --extra test pytest
 
 # Run all the tests for all the supported Python versions
 testall:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -142,7 +142,6 @@ select = [
     # prefix
     "ERA",    # https://docs.astral.sh/ruff/rules/#eradicate-era
     "FAST",   # https://docs.astral.sh/ruff/rules/#fastapi-fast
-    "I",      # https://docs.astral.sh/ruff/rules/#isort-i
     "ANN",    # https://docs.astral.sh/ruff/rules/#flake8-annotations-ann
     "ASYNC",  # https://docs.astral.sh/ruff/rules/#flake8-async-async
     "S",      # https://docs.astral.sh/ruff/rules/#flake8-bandit-s
@@ -150,13 +149,13 @@ select = [
     "FBT",    # https://docs.astral.sh/ruff/rules/#flake8-boolean-trap-fbt
     "B",      # https://docs.astral.sh/ruff/rules/#flake8-bugbear-b
     "A",      # https://docs.astral.sh/ruff/rules/#flake8-builtins-a
-    "C",      # https://docs.astral.sh/ruff/rules/#flake8-comprehensions-c4
+    "C4",     # https://docs.astral.sh/ruff/rules/#flake8-comprehensions-c4
     "EM",     # https://docs.astral.sh/ruff/rules/#flake8-errmsg-em
     "FIX",    # https://docs.astral.sh/ruff/rules/#flake8-fixme-fix
     "ISC",    # https://docs.astral.sh/ruff/rules/#flake8-implicit-str-concat-isc
     "INP",    # https://docs.astral.sh/ruff/rules/#flake8-no-pep420-inp
     "PIE",    # https://docs.astral.sh/ruff/rules/#flake8-pie-pie
-    "T",      # https://docs.astral.sh/ruff/rules/#flake8-print-t20
+    "T20",    # https://docs.astral.sh/ruff/rules/#flake8-print-t20
     "PT",     # https://docs.astral.sh/ruff/rules/#flake8-pytest-style-pt
     "RSE",    # https://docs.astral.sh/ruff/rules/#flake8-raise-rse
     "RET",    # https://docs.astral.sh/ruff/rules/#flake8-return-ret
@@ -166,7 +165,7 @@ select = [
     "PTH",    # https://docs.astral.sh/ruff/rules/#flake8-use-pathlib-pth
     "FLY",    # https://docs.astral.sh/ruff/rules/#flynt-fly
     "I",      # https://docs.astral.sh/ruff/rules/#isort-i
-    "C",      # https://docs.astral.sh/ruff/rules/#mccabe-c90
+    "C90",    # https://docs.astral.sh/ruff/rules/#mccabe-c90
     "N",      # https://docs.astral.sh/ruff/rules/#pep8-naming-n
     "PERF",   # https://docs.astral.sh/ruff/rules/#perflint-perf
     "E", "W", # https://docs.astral.sh/ruff/rules/#pycodestyle-e-w
@@ -186,7 +185,6 @@ select = [
     "TC010",  # https://docs.astral.sh/ruff/rules/runtime-string-union
 ]
 
-extend-select = ["RUF100", ]  # RUF100=unused-noqa,
 ignore = [
     "D100", # ignore missing docstring in module
     "D102", # ignore missing docstring in public method

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -100,42 +100,142 @@ bump = true
 air = { workspace = true }
 
 [tool.ruff]
+src = ["src"]
 line-length = 120
-target-version = "py313"
 indent-width = 4
+# Allow fix for all enabled rules (when `--fix`) is provided.
+fixable = ["ALL"]
+unfixable = []
+# Exclude a variety of commonly ignored directories.
+exclude = [
+    ".git",
+    ".github",
+    ".mypy_cache",
+    ".pytest_cache",
+    ".ruff_cache",
+    ".venv",
+    ".vscode",
+    ".cursor",
+    ".idea",
+    "__pypackages__",
+    "build",
+    "dist",
+    "site-packages",
+]
 
 [tool.ruff.format]
 indent-style = "space"   # match EditorConfig
 line-ending = "lf"       # enforce LF newlines
 quote-style = "double"   # keep quotes in sync with flake8-quotes
+# Docstring code formatting
+docstring-code-format = true # format Python code blocks in docstrings
+docstring-code-line-length = "dynamic" # int | "dynamic" (used only if above is true)
+# Trailing-comma behavior (Black's “magic comma”)
+skip-magic-trailing-comma = false # leave multi-line when trailing comma present
+# Formatter-only file excludes (extra to top-level exclude/extend-exclude)
+exclude = []
+# Opt into preview (experimental) formatting style
+preview = false
 
 [tool.ruff.lint]
-# E/W = pycodestyle; F = pyflakes; Q = flake8-quotes; UP = pyupgrade
-# I = isort; N = pep8-naming; B = bugbear; T201/T203 = flake8-print
-select = ["E", "F", "W", "Q", "UP", "I", "N", "B", "T201", "T203"]
-extend-select = ["RUF100", "C90", "D"]  # RUF100=unused-noqa, C90=McCabe, D=pydocstyle
+select = [
+    # prefix
+    "ERA",    # https://docs.astral.sh/ruff/rules/#eradicate-era
+    "FAST",   # https://docs.astral.sh/ruff/rules/#fastapi-fast
+    "I",      # https://docs.astral.sh/ruff/rules/#isort-i
+    "ANN",    # https://docs.astral.sh/ruff/rules/#flake8-annotations-ann
+    "ASYNC",  # https://docs.astral.sh/ruff/rules/#flake8-async-async
+    "S",      # https://docs.astral.sh/ruff/rules/#flake8-bandit-s
+    "BLE",    # https://docs.astral.sh/ruff/rules/#flake8-blind-except-ble
+    "FBT",    # https://docs.astral.sh/ruff/rules/#flake8-boolean-trap-fbt
+    "B",      # https://docs.astral.sh/ruff/rules/#flake8-bugbear-b
+    "A",      # https://docs.astral.sh/ruff/rules/#flake8-builtins-a
+    "C",      # https://docs.astral.sh/ruff/rules/#flake8-comprehensions-c4
+    "EM",     # https://docs.astral.sh/ruff/rules/#flake8-errmsg-em
+    "FIX",    # https://docs.astral.sh/ruff/rules/#flake8-fixme-fix
+    "ISC",    # https://docs.astral.sh/ruff/rules/#flake8-implicit-str-concat-isc
+    "INP",    # https://docs.astral.sh/ruff/rules/#flake8-no-pep420-inp
+    "PIE",    # https://docs.astral.sh/ruff/rules/#flake8-pie-pie
+    "T",      # https://docs.astral.sh/ruff/rules/#flake8-print-t20
+    "PT",     # https://docs.astral.sh/ruff/rules/#flake8-pytest-style-pt
+    "RSE",    # https://docs.astral.sh/ruff/rules/#flake8-raise-rse
+    "RET",    # https://docs.astral.sh/ruff/rules/#flake8-return-ret
+    "SIM",    # https://docs.astral.sh/ruff/rules/#flake8-simplify-sim
+    "SLOT",   # https://docs.astral.sh/ruff/rules/#flake8-slots-slot
+    "ARG",    # https://docs.astral.sh/ruff/rules/#flake8-unused-arguments-arg
+    "PTH",    # https://docs.astral.sh/ruff/rules/#flake8-use-pathlib-pth
+    "FLY",    # https://docs.astral.sh/ruff/rules/#flynt-fly
+    "I",      # https://docs.astral.sh/ruff/rules/#isort-i
+    "C",      # https://docs.astral.sh/ruff/rules/#mccabe-c90
+    "N",      # https://docs.astral.sh/ruff/rules/#pep8-naming-n
+    "PERF",   # https://docs.astral.sh/ruff/rules/#perflint-perf
+    "E", "W", # https://docs.astral.sh/ruff/rules/#pycodestyle-e-w
+    "DOC",    # https://docs.astral.sh/ruff/rules/#pydoclint-doc
+    "D",      # https://docs.astral.sh/ruff/rules/#pydocstyle-d
+    "PGH",    # https://docs.astral.sh/ruff/rules/#pygrep-hooks-pgh
+    "PL",     # https://docs.astral.sh/ruff/rules/#pylint-pl
+    "UP",     # https://docs.astral.sh/ruff/rules/#pyupgrade-up
+    "FURB",   # https://docs.astral.sh/ruff/rules/#refurb-furb
+    "RUF",    # https://docs.astral.sh/ruff/rules/#ruff-specific-rules-ruf
+    "TRY",    # https://docs.astral.sh/ruff/rules/#tryceratops-try
+    # Full rule code
+    "ICN003", # https://docs.astral.sh/ruff/rules/banned-import-from
+    "TC004",  # https://docs.astral.sh/ruff/rules/runtime-import-in-type-checking-block
+    "TC005",  # https://docs.astral.sh/ruff/rules/empty-type-checking-block
+    "TC008",  # https://docs.astral.sh/ruff/rules/quoted-type-alias
+    "TC010",  # https://docs.astral.sh/ruff/rules/runtime-string-union
+]
+
+extend-select = ["RUF100", ]  # RUF100=unused-noqa,
 ignore = [
     "D100", # ignore missing docstring in module
     "D102", # ignore missing docstring in public method
     "D104", # ignore missing docstring in public package
     "D105", # ignore missing docstring in magic methods
     "D107", # ignore missing docstring in __init__ methods
+    "D206", # docstring-tab-indentation (formatter handles indentation)
+    "D300", # triple-single-quotes (formatter enforces double quotes)
+    "ANN101", "ANN102", # skip self/cls annotation rules
 ]
+
+[tool.ruff.lint.flake8-import-conventions]
+# Declare the banned `from` imports.
+banned-from = ["air"]
 
 [tool.ruff.lint.isort]
 combine-as-imports = true     # group aliases coming from the same module
 force-wrap-aliases = true     # keep the multi-line, parenthesised layout
+# Help Ruff classify your own package as first-party (very important for stable sorting)
+known-first-party = ["air"]
+# Extra safety: mark imports from the same package as first-party when inside it
+detect-same-package = true
+# Keep the standard section order; set explicitly for clarity
+section-order = ["future", "standard-library", "third-party", "first-party", "local-folder"]
+# Keep type-based ordering (default, but set explicitly)
+order-by-type = true
+# Do NOT set these (formatter conflicts):
+# force-single-line, lines-after-imports, lines-between-types, split-on-trailing-comma
 
 [tool.ruff.lint.pydocstyle]
 convention = "google"
 
-[tool.ruff.lint.flake8-quotes]
-inline-quotes = "double"
-multiline-quotes = "double"
-docstring-quotes = "double"
-
 [tool.ruff.lint.mccabe]
 max-complexity = 10  # set the C901 threshold explicitly
+
+[tool.ruff.lint.flake8-type-checking]
+# Do NOT auto-quote annotations; prefer normal annotations.
+quote-annotations = false
+# These must exist at runtime (annotations are read/used), so don't gate their imports
+runtime-evaluated-base-classes = [
+    "pydantic.BaseModel",
+]
+runtime-evaluated-decorators = [
+    "dataclasses.dataclass",
+    "pydantic.validate_call",
+    "fastapi.FastAPI.get",
+]
+# Modules that are always safe to import (never gate)
+exempt-modules = ["typing", "typing_extensions"]
 
 [tool.codespell]
 # Ref: https://github.com/codespell-project/codespell#using-a-config-file

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -220,7 +220,7 @@ select = [
     "E", "W", # https://docs.astral.sh/ruff/rules/#pycodestyle-e-w
     "DOC",    # https://docs.astral.sh/ruff/rules/#pydoclint-doc
     "D",      # https://docs.astral.sh/ruff/rules/#pydocstyle-d
-    "D",      # https://docs.astral.sh/ruff/rules/#pyflakes-f
+    "F",      # https://docs.astral.sh/ruff/rules/#pyflakes-f
     "PGH",    # https://docs.astral.sh/ruff/rules/#pygrep-hooks-pgh
     "PL",     # https://docs.astral.sh/ruff/rules/#pylint-pl
     "UP",     # https://docs.astral.sh/ruff/rules/#pyupgrade-up

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,13 +6,8 @@ authors = [
     { name = "Audrey M. Roy Greenfeld", email = "audrey@feldroy.com" },
     { name = "Daniel Roy Greenfeld", email = "daniel@feldroy.com" }
 ]
-dependencies = [
-    "fastapi>=0.116.1",
-    "Jinja2>=3.1.6",
-    "python-multipart>=0.0.20",
-]
-
 readme = "README.md"
+license = { file = "LICENSE" }
 requires-python = ">= 3.10"
 classifiers = [
     "Operating System :: OS Independent",
@@ -35,15 +30,35 @@ classifiers = [
     "Programming Language :: Python :: 3.13",
 ]
 
+[project.urls]
+Homepage = "https://github.com/feldroy/air"
+Docs = "https://airdocs.fastapicloud.dev"
+bugs = "https://github.com/feldroy/air/issues"
+
 [project.scripts]
 "air" = "air.cli:app"
 
+# region dependencies
+project.dependencies = [
+    "fastapi>=0.116.1",
+    "Jinja2>=3.1.6",
+    "python-multipart>=0.0.20",
+]
+
+# Runtime extras you want users to install from PyPI
 [project.optional-dependencies]
-# Make `air[standard]` install FastAPI’s own “standard” extras, available with: uv pip install "air[standard]".
+# Make `air[standard]` install FastAPI’s own “standard” extras,
+# so *users* can do: uv pip install "air[standard]".
 standard = [
     # Re-install FastAPI with its “standard” extra.
     "fastapi[standard]>=0.116.1",
 ]
+
+[dependency-groups]
+# Groups are for contributors; install with: uv sync --group NAME
+# Developer-only deps (dev/test/docs) under [dependency-groups],
+# so uv sync can install them for contributors.
+# (Groups are not published to PyPI (meaning: they’re not visible to end users).)
 dev = [
     # Justfile tasks
     "rust-just>=1.42.3",
@@ -75,21 +90,49 @@ docs = [
     "mkdocstrings[python]",
     "mkdocs-autorefs>=1.4.2",
 ]
-
-[project.urls]
-homepage = "https://github.com/feldroy/air"
-bugs = "https://github.com/feldroy/air/issues"
+# endregion
 
 [tool.mypy]
 exclude = "^build/"
+
+# -------- pytest: make tests import from src/ --------
+[tool.pytest.ini_options]
+pythonpath = ["src"]
+testpaths = ["tests"]
 
 [tool.coverage.run]
 omit = [
     "tests/*",
 ]
 
+# region uv
 [tool.uv]
 package = true
+# Keep defaults explicit; dev, test groups installs on `uv sync`
+default-groups = ["dev", "test"]
+# Dev tools require modern Python while the library supports older (meaning: earlier) versions
+
+[tool.uv.dependency-groups]
+dev = { requires-python = ">=3.10" }
+# Speed up rebuilds of the editable install
+cache-keys = [
+  { file = "pyproject.toml" },
+  { file = "uv.lock" },
+  { dir = "src" },
+  { dir = "tests" },
+  { file = "README.md" },
+]
+
+# -------- uv build backend (fast and strict) --------
+[build-system]
+requires = ["uv_build>=0.8.7,<0.9.0"]
+build-backend = "uv_build"
+
+[tool.uv.build-backend]
+# src is default, but we state it for clarity
+module-root = "src"
+# Your single top-level package under src
+module-name = "air"
 
 [tool.uv-dynamic-versioning]
 vcs = "git"
@@ -97,8 +140,11 @@ style = "pep440"
 bump = true
 
 [tool.uv.sources]
+# Tells uv to use the local workspace air instead of PyPI.
 air = { workspace = true }
+# endregion
 
+# region ruff
 [tool.ruff]
 src = ["src"]
 line-length = 120
@@ -184,7 +230,6 @@ select = [
     "TC008",  # https://docs.astral.sh/ruff/rules/quoted-type-alias
     "TC010",  # https://docs.astral.sh/ruff/rules/runtime-string-union
 ]
-
 ignore = [
     "D100", # ignore missing docstring in module
     "D102", # ignore missing docstring in public method
@@ -234,6 +279,7 @@ runtime-evaluated-decorators = [
 ]
 # Modules that are always safe to import (never gate)
 exempt-modules = ["typing", "typing_extensions"]
+# endregion
 
 [tool.codespell]
 # Ref: https://github.com/codespell-project/codespell#using-a-config-file

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -145,6 +145,10 @@ air = { workspace = true }
 
 # region ruff
 [tool.ruff]
+# Keep file discovery identical whether you pass "." or not
+respect-gitignore = true  # default, shown for clarity
+force-exclude = true      # apply excludes even for explicit paths like "."
+
 src = ["src"]
 line-length = 120
 indent-width = 4
@@ -216,6 +220,7 @@ select = [
     "E", "W", # https://docs.astral.sh/ruff/rules/#pycodestyle-e-w
     "DOC",    # https://docs.astral.sh/ruff/rules/#pydoclint-doc
     "D",      # https://docs.astral.sh/ruff/rules/#pydocstyle-d
+    "D",      # https://docs.astral.sh/ruff/rules/#pyflakes-f
     "PGH",    # https://docs.astral.sh/ruff/rules/#pygrep-hooks-pgh
     "PL",     # https://docs.astral.sh/ruff/rules/#pylint-pl
     "UP",     # https://docs.astral.sh/ruff/rules/#pyupgrade-up
@@ -279,6 +284,47 @@ runtime-evaluated-decorators = [
 # Modules that are always safe to import (never gate)
 exempt-modules = ["typing", "typing_extensions"]
 # endregion ruff
+
+# region ty
+[tool.ty.src]
+# Lock what gets checked so "ty check" and "ty check ." act the same
+include = ["src", "tests"] # keep discovery stable
+# Keep Ty aligned with .gitignore and friends (default = true; shown for clarity).
+respect-ignore-files = true
+
+[tool.ty.environment]
+# Optional: make first-party resolution stable
+root = ["./src", "."]
+
+[tool.ty.terminal]
+# Fail the run on any warning.
+error-on-warning = true
+# Short, readable output; switch to "full" when debugging.
+output-format = "concise"
+
+# Promote every non-error rule to error (strict).
+[tool.ty.rules]
+deprecated = "error"
+invalid-ignore-comment = "error"
+possibly-unbound-attribute = "error"
+possibly-unbound-implicit-call = "error"
+possibly-unbound-import = "error"
+redundant-cast = "error"
+undefined-reveal = "error"
+unknown-rule = "error"
+unresolved-global = "error"
+unsupported-base = "error"
+division-by-zero = "error"
+possibly-unresolved-reference = "error"
+unused-ignore-comment = "error"
+
+# Tests often import optional dev deps or use dynamic patterns.
+[[tool.ty.overrides]]
+include = ["tests/**", "**/test_*.py", "**/*_test.py"]
+[tool.ty.overrides.rules]
+unresolved-import               = "warn"
+possibly-unresolved-reference   = "warn"
+# endregion ty
 
 [tool.codespell]
 # Ref: https://github.com/codespell-project/codespell#using-a-config-file

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@ classifiers = [
 [project.urls]
 Homepage = "https://github.com/feldroy/air"
 Docs = "https://airdocs.fastapicloud.dev"
-bugs = "https://github.com/feldroy/air/issues"
+Issues = "https://github.com/feldroy/air/issues"
 
 [project.scripts]
 "air" = "air.cli:app"
@@ -110,10 +110,10 @@ omit = [
 package = true
 # Keep defaults explicit; dev, test groups installs on `uv sync`
 default-groups = ["dev", "test"]
-# Dev tools require modern Python while the library supports older (meaning: earlier) versions
 
 [tool.uv.dependency-groups]
-dev = { requires-python = ">=3.10" }
+# Dev tools require modern Python while the library supports older versions
+dev = { requires-python = ">=3.13" }
 # Speed up rebuilds of the editable install
 cache-keys = [
   { file = "pyproject.toml" },

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,6 +67,8 @@ test = [
     "types-Markdown>=3.8.0",
     # Lets you run full example apps
     "uvicorn>=0.34.0",
+    # Fix common misspellings in text files
+    "codespell>=2.4.1",
 ]
 docs = [
     "mkdocs-material",
@@ -89,9 +91,56 @@ omit = [
 [tool.uv]
 package = true
 
-[tool.ruff]                  # enable import-sorting in the linter
-lint.select = ["I"]          # I-rules = isort compatibility
+[tool.uv-dynamic-versioning]
+vcs = "git"
+style = "pep440"
+bump = true
+
+[tool.uv.sources]
+air = { workspace = true }
+
+[tool.ruff]
+line-length = 120
+target-version = "py313"
+indent-width = 4
+
+[tool.ruff.format]
+indent-style = "space"   # match EditorConfig
+line-ending = "lf"       # enforce LF newlines
+quote-style = "double"   # keep quotes in sync with flake8-quotes
+
+[tool.ruff.lint]
+# E/W = pycodestyle; F = pyflakes; Q = flake8-quotes; UP = pyupgrade
+# I = isort; N = pep8-naming; B = bugbear; T201/T203 = flake8-print
+select = ["E", "F", "W", "Q", "UP", "I", "N", "B", "T201", "T203"]
+extend-select = ["RUF100", "C90", "D"]  # RUF100=unused-noqa, C90=McCabe, D=pydocstyle
+ignore = [
+    "D100", # ignore missing docstring in module
+    "D102", # ignore missing docstring in public method
+    "D104", # ignore missing docstring in public package
+    "D105", # ignore missing docstring in magic methods
+    "D107", # ignore missing docstring in __init__ methods
+]
 
 [tool.ruff.lint.isort]
-combine-as-imports = true    # group aliases coming from the same module
-force-wrap-aliases = true    # keep the multi-line, parenthesised layout
+combine-as-imports = true     # group aliases coming from the same module
+force-wrap-aliases = true     # keep the multi-line, parenthesised layout
+
+[tool.ruff.lint.pydocstyle]
+convention = "google"
+
+[tool.ruff.lint.flake8-quotes]
+inline-quotes = "double"
+multiline-quotes = "double"
+docstring-quotes = "double"
+
+[tool.ruff.lint.mccabe]
+max-complexity = 10  # set the C901 threshold explicitly
+
+[tool.codespell]
+# Ref: https://github.com/codespell-project/codespell#using-a-config-file
+skip = '.git*,*.svg,*.lock,*.css,*.yaml'
+check-hidden = true
+# Ignore "formatting" like **L**anguage
+ignore-regex = '\*\*[A-Z]\*\*[a-z]+\b'
+ignore-words-list = 'asend,aci'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,11 +39,10 @@ Issues = "https://github.com/feldroy/air/issues"
 "air" = "air.cli:app"
 
 # region dependencies
-project.dependencies = [
-    "fastapi>=0.116.1",
-    "Jinja2>=3.1.6",
-    "python-multipart>=0.0.20",
-]
+[project.dependencies]
+fastapi = ">=0.116.1"
+jinja2 = ">=3.1.6"
+python-multipart = ">=0.0.20"
 
 # Runtime extras you want users to install from PyPI
 [project.optional-dependencies]
@@ -90,7 +89,7 @@ docs = [
     "mkdocstrings[python]",
     "mkdocs-autorefs>=1.4.2",
 ]
-# endregion
+# endregion dependencies
 
 [tool.mypy]
 exclude = "^build/"
@@ -142,7 +141,7 @@ bump = true
 [tool.uv.sources]
 # Tells uv to use the local workspace air instead of PyPI.
 air = { workspace = true }
-# endregion
+# endregion uv
 
 # region ruff
 [tool.ruff]
@@ -279,7 +278,7 @@ runtime-evaluated-decorators = [
 ]
 # Modules that are always safe to import (never gate)
 exempt-modules = ["typing", "typing_extensions"]
-# endregion
+# endregion ruff
 
 [tool.codespell]
 # Ref: https://github.com/codespell-project/codespell#using-a-config-file

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.10"
 resolution-markers = [
     "python_full_version >= '3.11'",
@@ -29,6 +29,7 @@ standard = [
     { name = "fastapi", extra = ["standard"] },
 ]
 test = [
+    { name = "codespell" },
     { name = "coverage" },
     { name = "httpx" },
     { name = "ipdb" },
@@ -42,6 +43,7 @@ test = [
 
 [package.metadata]
 requires-dist = [
+    { name = "codespell", marker = "extra == 'test'", specifier = ">=2.4.1" },
     { name = "coverage", marker = "extra == 'test'", specifier = ">=7.8.2" },
     { name = "fastapi", specifier = ">=0.116.1" },
     { name = "fastapi", extras = ["standard"], marker = "extra == 'standard'", specifier = ">=0.116.1" },
@@ -198,6 +200,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/60/6c/8ca2efa64cf75a977a0d7fac081354553ebe483345c734fb6b6515d96bbc/click-8.2.1.tar.gz", hash = "sha256:27c491cc05d968d271d5a1db13e3b5a184636d9d930f148c50b038f0d0646202", size = 286342, upload-time = "2025-05-20T23:19:49.832Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/85/32/10bb5764d90a8eee674e9dc6f4db6a0ab47c8c4d0d83c27f7c39ac415a4d/click-8.2.1-py3-none-any.whl", hash = "sha256:61a3265b914e850b85317d0b3109c7f8cd35a670f963866005d6ef1d5175a12b", size = 102215, upload-time = "2025-05-20T23:19:47.796Z" },
+]
+
+[[package]]
+name = "codespell"
+version = "2.4.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/15/e0/709453393c0ea77d007d907dd436b3ee262e28b30995ea1aa36c6ffbccaf/codespell-2.4.1.tar.gz", hash = "sha256:299fcdcb09d23e81e35a671bbe746d5ad7e8385972e65dbb833a2eaac33c01e5", size = 344740, upload-time = "2025-01-28T18:52:39.411Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/20/01/b394922252051e97aab231d416c86da3d8a6d781eeadcdca1082867de64e/codespell-2.4.1-py3-none-any.whl", hash = "sha256:3dadafa67df7e4a3dbf51e0d7315061b80d265f9552ebd699b3dd6834b47e425", size = 344501, upload-time = "2025-01-28T18:52:37.057Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
```
### Description

This pull request includes the following updates:

- Removed a redundant Ruff linting step from `justfile`.
- Configured Ruff with detailed linting rules and improved formatting.
- Added `codespell` as a dependency and configured Ruff to leverage it for more comprehensive linting.

### Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Maintenance/Chore update

### Steps to Test

1. Run the `just` commands to verify Ruff is configured correctly.
2. Check whether the codespell integration works with Ruff.
3. Ensure no redundant lint steps are executed.

### Related Issues

N/A
```