### PR TITLE
Support MVP.css air.Header tag not being in body

### DIFF
--- a/src/air/layouts.py
+++ b/src/air/layouts.py
@@ -1,17 +1,38 @@
-from .tags import Base, Body, Head, Html, Link, Main, Meta, Script, Style, Tag, Title
+from .tags import (
+    Base,
+    Body,
+    Head,
+    Html,
+    Link,
+    Main,
+    Meta,
+    Script,
+    Style,
+    Tag,
+    Title,
+    Header,
+)
 
 # ruff: noqa F841
 HEAD_TAG_TYPES: tuple[type[Tag], ...] = (Title, Style, Meta, Link, Script, Base)
 
 
 def filter_body_tags(tags) -> list:
-    """Given a list of tags, only list the ones that belong in body."""
+    """Given a list of tags, only list the ones that belong in body of an HTML document."""
     return [t for t in tags if not isinstance(t, HEAD_TAG_TYPES)]
 
 
 def filter_head_tags(tags) -> list:
-    """Given a list of tags, only list the ones that belong in head."""
+    """Given a list of tags, only list the ones that belong in head of an HTML document."""
     return [t for t in tags if isinstance(t, HEAD_TAG_TYPES)]
+
+
+def _header(tags) -> Header | str:
+    """Extracts the air.Header tag from a set of tags."""
+    for tag in tags:
+        if isinstance(tag, Header):
+            return tag
+    return ""
 
 
 def mvpcss(*children, htmx: bool = True, **kwargs):
@@ -19,7 +40,8 @@ def mvpcss(*children, htmx: bool = True, **kwargs):
 
     1. At the top level HTML head tags are put in the `<head>` tag
     2. Otherwise everything is put in the `<body>`
-    3. HTMX is the default, change with the `htmx` keyword argument
+    3. Header and Nav tags are placed in the top of the body above the Main tag
+    4. HTMX is the default, change with the `htmx` keyword argument
 
     Note: The `mvpcss` function is a quick prototyping tool. It isn't designed to be extensible.
         Rather the `mvpcss` layout function makes it easy to roll out quick demonstrations and proofs-of-concept.
@@ -28,6 +50,7 @@ def mvpcss(*children, htmx: bool = True, **kwargs):
     """
     body_tags = filter_body_tags(children)
     head_tags = filter_head_tags(children)
+
     if htmx:
         head_tags.insert(
             0,
@@ -42,7 +65,10 @@ def mvpcss(*children, htmx: bool = True, **kwargs):
             Link(rel="stylesheet", href="https://unpkg.com/mvp.css"),
             *head_tags,
         ),
-        Body(Main(*body_tags)),
+        Body(
+            _header(body_tags),
+            Main(*[x for x in body_tags if not isinstance(x, Header)]),
+        ),
     ).render()
 
 

--- a/tests/test_layouts.py
+++ b/tests/test_layouts.py
@@ -23,3 +23,16 @@ def test_mvpcss_layout():
         """<!doctype html><html><head><link href="https://unpkg.com/mvp.css" rel="stylesheet" /><script src="https://cdn.jsdelivr.net/npm/htmx.org@2.0.6/dist/htmx.min.js" integrity="sha384-Akqfrbj/HpNVo8k11SXBb6TlBWmXXlYQrCSqEWmyKJe+hDm3Z/B2WVG4smwBkRVm" crossorigin="anonymous"></script><title>Cheese Monger</title></head><body><main><h1>Cheese Monger</h1></main></body></html>"""
         == html
     )
+
+
+def test_mvpcss_layout_header():
+    html = air.layouts.mvpcss(
+        air.Header(
+            air.H1("This is in the header"),
+        ),
+        air.P("This is in the main"),
+    )
+    assert (
+        html
+        == '<!doctype html><html><head><link href="https://unpkg.com/mvp.css" rel="stylesheet" /><script src="https://cdn.jsdelivr.net/npm/htmx.org@2.0.6/dist/htmx.min.js" integrity="sha384-Akqfrbj/HpNVo8k11SXBb6TlBWmXXlYQrCSqEWmyKJe+hDm3Z/B2WVG4smwBkRVm" crossorigin="anonymous"></script></head><body><header><h1>This is in the header</h1></header><main><p>This is in the main</p></main></body></html>'
+    )


### PR DESCRIPTION
This code:

```python
air.layouts.mvpcss(
        air.Header(
            air.Nav(
                air.A("Home", href="/"),
                air.Ul(
                    air.Li("Menu Item 1"),
                    air.Li(air.A("Menu Item 2", href="#section-1")),
                    air.Li(
                        air.A("Dropdown Menu Item", href="#"),
                        air.Ul(
                            air.Li(air.A("Sublink with a long name", href="#")),
                            air.Li(air.A("Short sublink", href="#")),
                        ),
                    ),
                ),
            ),
            air.H1("This is in the header"),
        ),
        air.P("This is in the main"),
)
```

Now generates this (Home should be an image):

<img width="785" height="420" alt="Screenshot 2025-08-13 at 06 51 23" src="https://github.com/user-attachments/assets/d7a9a82b-4211-4f4c-b4da-0ec1ec2d70dc" />
