### PR TITLE
Switch from pytest-rich to pytest-modern

### DIFF
--- a/.env
+++ b/.env
@@ -7,6 +7,6 @@ FORCE_COLOR=3
 CLICOLOR=1
 CLICOLOR_FORCE=1
 RICH_FORCE_TERMINAL=1
-PYTEST_ADDOPTS="--color=yes -rA --rich"  # quote values that contain spaces
+PYTEST_ADDOPTS="--color=yes -rA"  # quote values that contain spaces
 JUST_COLOR=always
 PYTHONUNBUFFERED=1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -72,7 +72,7 @@ test = [
     "httpx>=0.28.1",   # For the test client
     "pytest>=8.4.0",   # Test runner
     "pdbpp>=0.11.7",   # enables pdb++, a drop-in replacement for pdb
-    "pytest-rich",     # Leverage rich for richer test session output.
+    "pytest-modern",     # Leverage rich for richer test session output.
 ]
 docs = [
     "mkdocs-material",          # MkDocs theme
@@ -140,7 +140,6 @@ dev = { requires-python = ">=3.13" }
 # In mono-repo (meaning: multiple projects in one repo) or local dev, this guarantees
 # uv uses your checked-out code.
 air = { workspace = true }
-pytest-rich = { git = "https://github.com/nicoddemus/pytest-rich", rev = "main" }
 
 # -------- uv build backend (fast and strict) --------
 # ======================================================================

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -72,7 +72,7 @@ test = [
     "httpx>=0.28.1",   # For the test client
     "pytest>=8.4.0",   # Test runner
     "pdbpp>=0.11.7",   # enables pdb++, a drop-in replacement for pdb
-    "pytest-modern",     # Leverage rich for richer test session output.
+    "pytest-modern",     # Provides richer test session output.
 ]
 docs = [
     "mkdocs-material",          # MkDocs theme


### PR DESCRIPTION
For #274, this replaces the proof-of-concept and mostly unmaintained pytest-rich with its maintained successor, pytest-modern. While arguably not as pretty, it does produce correct results on assert. Also works great with pdbpp.