### PR TITLE
Add optional MCP integration for Air app with fastapi-mcp

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,6 +45,11 @@ standard = [
     # Re-install FastAPI with its “standard” extra.
     "fastapi[standard]>=0.116.1",
 ]
+# Make `air[mcp]` install FastAPI-MCP for exposing endpoints as MCP tools.
+# See install guide: https://fastapi-mcp.tadata.com/getting-started/installation
+mcp = [
+    "fastapi-mcp>=0.4.0",
+]
 
 # Groups are for contributors; install with: uv sync --group NAME
 # Developer-only deps under [dependency-groups],


### PR DESCRIPTION
### Description

This pull request introduces optional MCP (Message Control Protocol) integration for the Air app using fastapi-mcp. Key updates include:

- Added the `mcp` parameter for automatic MCP mounting over HTTP or SSE.
- Implemented helper methods `mcp_mount`, `mcp_refresh`, and `mcp_client_config`.
- Updated `pyproject.toml` to include a new dependency group `air[mcp]` for enabling this functionality.
- Improved and simplified docstrings related to initialization parameters.