### PR TITLE
Improve CI workflows, annotations in the GitHub using GitHub Actions and CI for ubuntu-latest, windows-latest, macos-latest 

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -51,7 +51,7 @@ jobs:
         uses: taiki-e/install-action@just
 
   qa:
-    name: QA (format, lint, types) (via just, uv, ruff and ty) • macOS
+    name: QA (format, lint, types) • macOS (via just, uv, ruff and ty)
     runs-on: macos-latest
     timeout-minutes: 15
     steps:
@@ -65,7 +65,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ ubuntu-latest, windows-latest, macos-latest ]
-    name: "Tests on Python versions 3.10–>3.13 • ${{ matrix.os }}"
+    name: "Tests on Python versions 3.10–>3.13 • ${{ matrix.os }}" (via just, uv, pytest, pytest-pretty)
     runs-on: ${{ matrix.os }}
     timeout-minutes: 45
     steps:
@@ -75,7 +75,7 @@ jobs:
       - name: "Tests on Python versions 3.10–>3.13 • ${{ matrix.os }}"
         run: just test-all
   test-coverage:
-    name: Measuring Coverage (via just, uv, pytest, pytest-pretty, pytest-cov and coverage[toml]) • macOS
+    name: Measuring Coverage • macOS (via just, uv, pytest, pytest-pretty, pytest-cov and coverage[toml])
     runs-on: macos-latest
     timeout-minutes: 25
     steps:

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -65,7 +65,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ ubuntu-latest, windows-latest, macos-latest ]
-    name: "Tests on Python versions 3.10–>3.13 • ${{ matrix.os }}" (via just, uv, pytest, pytest-pretty)
+    name: Tests on Python versions 3.10–>3.13 • "${{ matrix.os }}" (via just, uv, pytest, pytest-pretty)
     runs-on: ${{ matrix.os }}
     timeout-minutes: 45
     steps:

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -5,7 +5,7 @@
 # - No echo/group commands shown.
 # - Shared bootstrap steps are DRY via YAML anchors.
 
-name: Python package
+name: Python Package - CI
 
 on:
   push:
@@ -15,6 +15,22 @@ on:
 
 env:
   COLUMNS: 120
+
+# Cancel older runs for the same branch/PR (concurrency = run one at a time).
+# When you push several commits in a row, only the newest run continues; older ones are cancelled.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+# Least-privilege token by default.
+permissions:
+  contents: read
+
+# Consistent shell across OSes; override per-step if you need PowerShell/cmd.
+# Only `run.shell` / `run.working-directory` are supported here.
+defaults:
+  run:
+    shell: bash
 
 jobs:
   # Define shared bootstrap once (never runs; used for anchors).
@@ -35,29 +51,36 @@ jobs:
         uses: taiki-e/install-action@just
 
   qa:
-    name: QA (format, lint, types) (via just, uv, ruff and ty)
-    runs-on: ubuntu-latest
+    name: QA (format, lint, types) (via just, uv, ruff and ty) • macOS
+    runs-on: macos-latest
+    timeout-minutes: 15
     steps:
       - *checkout
       - *setup_uv
       - *install_just
-      - name: QA (format, lint, types) (via just, uv, ruff and ty)
+      - name: QA (format, lint, types) • macOS
         run: just qa
   test-all:
-    name: Test on 3.10–>3.13 (via just, uv, pytest and pytest-pretty)
-    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ ubuntu-latest, windows-latest, macos-latest ]
+    name: "Tests on Python versions 3.10–>3.13 • ${{ matrix.os }}"
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 45
     steps:
       - *checkout
       - *setup_uv
       - *install_just
-      - name: Test on 3.10–>3.13 (via just, uv, pytest and pytest-pretty)
+      - name: "Tests on Python versions 3.10–>3.13 • ${{ matrix.os }}"
         run: just test-all
   test-coverage:
-    name: Measuring Coverage (via just, uv, pytest, pytest-pretty, pytest-cov and coverage[toml])
-    runs-on: ubuntu-latest
+    name: Measuring Coverage (via just, uv, pytest, pytest-pretty, pytest-cov and coverage[toml]) • macOS
+    runs-on: macos-latest
+    timeout-minutes: 25
     steps:
       - *checkout
       - *setup_uv
       - *install_just
-      - name: Measuring Coverage (via just, uv, pytest, pytest-pretty, pytest-cov and coverage[toml])
+      - name: Measuring Coverage • macOS
         run: just test-coverage

--- a/.github/workflows/release-to-pypi.yml
+++ b/.github/workflows/release-to-pypi.yml
@@ -1,6 +1,9 @@
 # .github/workflows/publish-on-tag.yml
 name: Publish Python Package with uv
 
+permissions:
+  contents: write
+
 on:
   push:
     tags:
@@ -25,3 +28,19 @@ jobs:
       env:
         UV_PYPI_TOKEN: ${{ secrets.PYPI_API_TOKEN }}
       run: uv publish --token $UV_PYPI_TOKEN
+
+    - name: Run latest-tag
+      uses: EndBug/latest-tag@latest
+      with:
+        # You can change the name of the tag or branch with this input.
+        # Default: 'latest'
+        ref: latest
+        # If a description is provided, the action will use it to create an annotated tag. If none is given, the action will create a lightweight tag.
+        # Default: ''
+        description: The latest release.
+        # Force-update a branch instead of using a tag.
+        # Default: false
+        force-branch: false
+        # Directory to use when executing git commands
+        # Default: '${{ github.workspace }}'
+        git-directory: '${{ github.workspace }}'

--- a/README.md
+++ b/README.md
@@ -1,57 +1,8 @@
-<!-- Pyramid of logos: base row = 15, each row above has one fewer -->
 <p align="center">
-  <!-- Row 1 -->
-  <img src="https://raw.githubusercontent.com/feldroy/air/refs/heads/main/docs/img/logo-blue-369x369.png" height="75" width="155"/>
-</p>
-<p align="center">
-  <!-- Row 2 -->
-  <img src="https://raw.githubusercontent.com/feldroy/air/refs/heads/main/docs/img/logo-blue-369x369.png" height="45" width="45"/>
-  <img src="https://raw.githubusercontent.com/feldroy/air/refs/heads/main/docs/img/logo-blue-369x369.png" height="45" width="45"/>
-</p>
-<p align="center">
-  <!-- Row 3 -->
-  <img src="https://raw.githubusercontent.com/feldroy/air/refs/heads/main/docs/img/logo-blue-369x369.png" height="45" width="45"/>
-  <img src="https://raw.githubusercontent.com/feldroy/air/refs/heads/main/docs/img/logo-blue-369x369.png" height="45" width="45"/>
-  <img src="https://raw.githubusercontent.com/feldroy/air/refs/heads/main/docs/img/logo-blue-369x369.png" height="45" width="45"/>
-</p>
-<p align="center">
-  <!-- Row 4 -->
-  <img src="https://raw.githubusercontent.com/feldroy/air/refs/heads/main/docs/img/logo-blue-369x369.png" height="45" width="45"/>
-  <img src="https://raw.githubusercontent.com/feldroy/air/refs/heads/main/docs/img/logo-blue-369x369.png" height="45" width="45"/>
-  <img src="https://raw.githubusercontent.com/feldroy/air/refs/heads/main/docs/img/logo-blue-369x369.png" height="45" width="45"/>
-  <img src="https://raw.githubusercontent.com/feldroy/air/refs/heads/main/docs/img/logo-blue-369x369.png" height="45" width="45"/>
-</p>
-<p align="center">
-  <!-- Row 5 -->
-  <img src="https://raw.githubusercontent.com/feldroy/air/refs/heads/main/docs/img/logo-blue-369x369.png" height="45" width="45"/>
-  <img src="https://raw.githubusercontent.com/feldroy/air/refs/heads/main/docs/img/logo-blue-369x369.png" height="45" width="45"/>
-  <img src="https://raw.githubusercontent.com/feldroy/air/refs/heads/main/docs/img/logo-blue-369x369.png" height="45" width="45"/>
-  <img src="https://raw.githubusercontent.com/feldroy/air/refs/heads/main/docs/img/logo-blue-369x369.png" height="45" width="45"/>
-  <img src="https://raw.githubusercontent.com/feldroy/air/refs/heads/main/docs/img/logo-blue-369x369.png" height="45" width="45"/>
-</p>
-<p align="center">
-  <!-- Row 6 -->
-  <img src="https://raw.githubusercontent.com/feldroy/air/refs/heads/main/docs/img/logo-blue-369x369.png" height="45" width="45"/>
-  <img src="https://raw.githubusercontent.com/feldroy/air/refs/heads/main/docs/img/logo-blue-369x369.png" height="45" width="45"/>
-  <img src="https://raw.githubusercontent.com/feldroy/air/refs/heads/main/docs/img/logo-blue-369x369.png" height="45" width="45"/>
-  <img src="https://raw.githubusercontent.com/feldroy/air/refs/heads/main/docs/img/logo-blue-369x369.png" height="45" width="45"/>
-  <img src="https://raw.githubusercontent.com/feldroy/air/refs/heads/main/docs/img/logo-blue-369x369.png" height="45" width="45"/>
-  <img src="https://raw.githubusercontent.com/feldroy/air/refs/heads/main/docs/img/logo-blue-369x369.png" height="45" width="45"/>
-</p>
-<p align="center">
-  <!-- Row 7 -->
-  <img src="https://raw.githubusercontent.com/feldroy/air/refs/heads/main/docs/img/logo-blue-369x369.png" height="45" width="45"/>
-  <img src="https://raw.githubusercontent.com/feldroy/air/refs/heads/main/docs/img/logo-blue-369x369.png" height="45" width="45"/>
-  <img src="https://raw.githubusercontent.com/feldroy/air/refs/heads/main/docs/img/logo-blue-369x369.png" height="45" width="45"/>
-  <img src="https://raw.githubusercontent.com/feldroy/air/refs/heads/main/docs/img/logo-blue-369x369.png" height="45" width="45"/>
-  <img src="https://raw.githubusercontent.com/feldroy/air/refs/heads/main/docs/img/logo-blue-369x369.png" height="45" width="45"/>
-  <img src="https://raw.githubusercontent.com/feldroy/air/refs/heads/main/docs/img/logo-blue-369x369.png" height="45" width="45"/>
-  <img src="https://raw.githubusercontent.com/feldroy/air/refs/heads/main/docs/img/logo-blue-369x369.png" height="45" width="45"/>
+  <img src="https://raw.githubusercontent.com/feldroy/air/refs/heads/main/docs/img/logo-blue-369x369.png" height="175" width="645"/>
 </p>
 
-
-
->>>>>> #### <span style="color:#000000">Air 💨: The new web framework that breathes fresh air into Python web development. Built with FastAPI, Starlette, and Pydantic.</span>
+## Air 💨: The new web framework that breathes fresh air into Python web development. Built with FastAPI, Starlette, and Pydantic.
 
 [![CI](https://img.shields.io/github/actions/workflow/status/feldroy/air/python-package.yml?branch=main&logo=githubactions&label=CI)](https://github.com/feldroy/air/actions?query=workflow%3Apython-package+event%3Apush+branch%main)
 [![Coverage](https://coverage-badge.samuelcolvin.workers.dev/feldroy/air.svg)](https://coverage-badge.samuelcolvin.workers.dev/redirect/feldroy/air)

--- a/README.md
+++ b/README.md
@@ -22,6 +22,18 @@
         <img src="https://img.shields.io/discord/1388403469505007696?logo=discord"
             alt="Chat on Discord"></a>
 </p>
+<p align="center">
+  <!-- OS support: ubuntu-latest, windows-latest, macos-latest -->
+  <a href="https://github.com/feldroy/air/actions/workflows/python-package.yml?query=branch%3Amain" target="_blank">
+    <img src="https://img.shields.io/badge/Runs%20on-ubuntu--latest-E95420?logo=ubuntu&logoColor=white" alt="Runs on ubuntu-latest">
+  </a>
+  <a href="https://github.com/feldroy/air/actions/workflows/python-package.yml?query=branch%3Amain" target="_blank">
+    <img src="https://img.shields.io/badge/Runs%20on-windows--latest-0078D6?logo=windows&logoColor=white" alt="Runs on windows-latest">
+  </a>
+  <a href="https://github.com/feldroy/air/actions/workflows/python-package.yml?query=branch%3Amain" target="_blank">
+    <img src="https://img.shields.io/badge/Runs%20on-macos--latest-000000?logo=apple&logoColor=white" alt="Runs on macos-latest">
+  </a>
+</p>
 
 > [!CAUTION]
 > Air is currently in an alpha state. While breaking changes are becoming less common, nevertheless, anything and everything could change.
@@ -91,7 +103,7 @@ Then open your browser to <http://127.0.0.1:8000> to see the result.
 
 ## Combining FastAPI and Air
 
-Air is just a layer over FastAPI. So it is trivial to combine sophisticated HTML pages and a REST API into one app. 
+Air is just a layer over FastAPI. So it is trivial to combine sophisticated HTML pages and a REST API into one app.
 
 ```python
 import air
@@ -143,7 +155,7 @@ def api_root():
     return {"message": "Awesome SaaS is powered by FastAPI"}
 
 # Combining the Air and and FastAPI apps into one
-app.mount("/api", api)    
+app.mount("/api", api)
 ```
 
 Don't forget the Jinja template!

--- a/README.md
+++ b/README.md
@@ -1,39 +1,76 @@
+<!-- Pyramid of logos: base row = 15, each row above has one fewer -->
 <p align="center">
-  <a href="http://feldroy.github.io/air/"><img src="https://raw.githubusercontent.com/feldroy/air/refs/heads/main/docs/img/logo-blue-369x369.png" alt="Air: The new web framework that breathes fresh air into Python web development. Built with FastAPI, Starlette, and Pydantic."></a>
+  <!-- Row 1 -->
+  <img src="https://raw.githubusercontent.com/feldroy/air/refs/heads/main/docs/img/logo-blue-369x369.png" height="75" width="155"/>
+</p>
+<p align="center">
+  <!-- Row 2 -->
+  <img src="https://raw.githubusercontent.com/feldroy/air/refs/heads/main/docs/img/logo-blue-369x369.png" height="45" width="45"/>
+  <img src="https://raw.githubusercontent.com/feldroy/air/refs/heads/main/docs/img/logo-blue-369x369.png" height="45" width="45"/>
+</p>
+<p align="center">
+  <!-- Row 3 -->
+  <img src="https://raw.githubusercontent.com/feldroy/air/refs/heads/main/docs/img/logo-blue-369x369.png" height="45" width="45"/>
+  <img src="https://raw.githubusercontent.com/feldroy/air/refs/heads/main/docs/img/logo-blue-369x369.png" height="45" width="45"/>
+  <img src="https://raw.githubusercontent.com/feldroy/air/refs/heads/main/docs/img/logo-blue-369x369.png" height="45" width="45"/>
+</p>
+<p align="center">
+  <!-- Row 4 -->
+  <img src="https://raw.githubusercontent.com/feldroy/air/refs/heads/main/docs/img/logo-blue-369x369.png" height="45" width="45"/>
+  <img src="https://raw.githubusercontent.com/feldroy/air/refs/heads/main/docs/img/logo-blue-369x369.png" height="45" width="45"/>
+  <img src="https://raw.githubusercontent.com/feldroy/air/refs/heads/main/docs/img/logo-blue-369x369.png" height="45" width="45"/>
+  <img src="https://raw.githubusercontent.com/feldroy/air/refs/heads/main/docs/img/logo-blue-369x369.png" height="45" width="45"/>
+</p>
+<p align="center">
+  <!-- Row 5 -->
+  <img src="https://raw.githubusercontent.com/feldroy/air/refs/heads/main/docs/img/logo-blue-369x369.png" height="45" width="45"/>
+  <img src="https://raw.githubusercontent.com/feldroy/air/refs/heads/main/docs/img/logo-blue-369x369.png" height="45" width="45"/>
+  <img src="https://raw.githubusercontent.com/feldroy/air/refs/heads/main/docs/img/logo-blue-369x369.png" height="45" width="45"/>
+  <img src="https://raw.githubusercontent.com/feldroy/air/refs/heads/main/docs/img/logo-blue-369x369.png" height="45" width="45"/>
+  <img src="https://raw.githubusercontent.com/feldroy/air/refs/heads/main/docs/img/logo-blue-369x369.png" height="45" width="45"/>
+</p>
+<p align="center">
+  <!-- Row 6 -->
+  <img src="https://raw.githubusercontent.com/feldroy/air/refs/heads/main/docs/img/logo-blue-369x369.png" height="45" width="45"/>
+  <img src="https://raw.githubusercontent.com/feldroy/air/refs/heads/main/docs/img/logo-blue-369x369.png" height="45" width="45"/>
+  <img src="https://raw.githubusercontent.com/feldroy/air/refs/heads/main/docs/img/logo-blue-369x369.png" height="45" width="45"/>
+  <img src="https://raw.githubusercontent.com/feldroy/air/refs/heads/main/docs/img/logo-blue-369x369.png" height="45" width="45"/>
+  <img src="https://raw.githubusercontent.com/feldroy/air/refs/heads/main/docs/img/logo-blue-369x369.png" height="45" width="45"/>
+  <img src="https://raw.githubusercontent.com/feldroy/air/refs/heads/main/docs/img/logo-blue-369x369.png" height="45" width="45"/>
+</p>
+<p align="center">
+  <!-- Row 7 -->
+  <img src="https://raw.githubusercontent.com/feldroy/air/refs/heads/main/docs/img/logo-blue-369x369.png" height="45" width="45"/>
+  <img src="https://raw.githubusercontent.com/feldroy/air/refs/heads/main/docs/img/logo-blue-369x369.png" height="45" width="45"/>
+  <img src="https://raw.githubusercontent.com/feldroy/air/refs/heads/main/docs/img/logo-blue-369x369.png" height="45" width="45"/>
+  <img src="https://raw.githubusercontent.com/feldroy/air/refs/heads/main/docs/img/logo-blue-369x369.png" height="45" width="45"/>
+  <img src="https://raw.githubusercontent.com/feldroy/air/refs/heads/main/docs/img/logo-blue-369x369.png" height="45" width="45"/>
+  <img src="https://raw.githubusercontent.com/feldroy/air/refs/heads/main/docs/img/logo-blue-369x369.png" height="45" width="45"/>
+  <img src="https://raw.githubusercontent.com/feldroy/air/refs/heads/main/docs/img/logo-blue-369x369.png" height="45" width="45"/>
 </p>
 
-<p align="center">
-    <em>Air: The new web framework that breathes fresh air into Python web development. Built with FastAPI, Starlette, and Pydantic.</em>
-</p>
 
-<p align="center">
-<a href="https://github.com/feldroy/air/actions?query=workflow%3Apython-package+event%3Apush+branch%main" target="_blank">
-    <img src="https://github.com/feldroy/air/actions/workflows/python-package.yml/badge.svg?event=push&branch=main" alt="Test">
-</a>
-<a href="https://pypi.org/project/air" target="_blank">
-    <img src="https://img.shields.io/pypi/v/air?color=%2334D058&label=pypi%20package" alt="Package version">
-</a>
-<a href="https://pypi.org/project/air" target="_blank">
-    <img src="https://img.shields.io/pypi/pyversions/air.svg?color=%2334D058" alt="Supported Python versions">
-</a>
-</p>
-<p align="center">
-        <a href="https://discord.gg/aTzWBVrtEs">
-        <img src="https://img.shields.io/discord/1388403469505007696?logo=discord"
-            alt="Chat on Discord"></a>
-</p>
-<p align="center">
-  <!-- OS support: ubuntu-latest, windows-latest, macos-latest -->
-  <a href="https://github.com/feldroy/air/actions/workflows/python-package.yml?query=branch%3Amain" target="_blank">
-    <img src="https://img.shields.io/badge/Runs%20on-ubuntu--latest-E95420?logo=ubuntu&logoColor=white" alt="Runs on ubuntu-latest">
-  </a>
-  <a href="https://github.com/feldroy/air/actions/workflows/python-package.yml?query=branch%3Amain" target="_blank">
-    <img src="https://img.shields.io/badge/Runs%20on-windows--latest-0078D6?logo=windows&logoColor=white" alt="Runs on windows-latest">
-  </a>
-  <a href="https://github.com/feldroy/air/actions/workflows/python-package.yml?query=branch%3Amain" target="_blank">
-    <img src="https://img.shields.io/badge/Runs%20on-macos--latest-000000?logo=apple&logoColor=white" alt="Runs on macos-latest">
-  </a>
-</p>
+
+>>>>>> #### <span style="color:#000000">Air 💨: The new web framework that breathes fresh air into Python web development. Built with FastAPI, Starlette, and Pydantic.</span>
+
+[![CI](https://img.shields.io/github/actions/workflow/status/feldroy/air/python-package.yml?branch=main&logo=githubactions&label=CI)](https://github.com/feldroy/air/actions?query=workflow%3Apython-package+event%3Apush+branch%main)
+[![Coverage](https://coverage-badge.samuelcolvin.workers.dev/feldroy/air.svg)](https://coverage-badge.samuelcolvin.workers.dev/redirect/feldroy/air)
+[![PyPI - Version](https://img.shields.io/pypi/v/air?logo=pypi)](https://pypi.org/project/air)
+[![Python Versions](https://img.shields.io/pypi/pyversions/air?logo=python)](https://pypi.org/project/air)
+[![GitHub License](https://img.shields.io/github/license/feldroy/air?logo=github)](https://github.com/feldroy/air/blob/main/LICENSE)
+
+[![PyPI Total Downloads](https://static.pepy.tech/badge/air)](https://pepy.tech/projects/air)
+[![PyPI Monthly Downloads](https://static.pepy.tech/badge/air/month)](https://pepy.tech/projects/air)
+[![PyPI Weekly Downloads](https://static.pepy.tech/badge/air/week)](https://pepy.tech/projects/air)
+
+![GitHub commit activity](https://img.shields.io/github/commit-activity/t/feldroy/air?logo=github)
+![GitHub commits since latest release](https://img.shields.io/github/commits-since/feldroy/air/latest?logo=github)
+[![GitHub last commit](https://img.shields.io/github/last-commit/feldroy/air?logo=github)](https://github.com/feldroy/air/commit/main)
+[![GitHub Release Date](https://img.shields.io/github/release-date/feldroy/air?logo=github)](https://github.com/feldroy/air/releases/latest)
+![GitHub tag check runs](https://img.shields.io/github/check-runs/feldroy/air/latest?logo=githubactions)
+
+[![GitHub contributors](https://img.shields.io/github/contributors/feldroy/air?logo=github)](https://github.com/feldroy/air/graphs/contributors)
+[![Discord](https://img.shields.io/discord/1388403469505007696?logo=discord)](https://discord.gg/aTzWBVrtEs)
 
 > [!CAUTION]
 > Air is currently in an alpha state. While breaking changes are becoming less common, nevertheless, anything and everything could change.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -69,11 +69,12 @@ lint = [
 ]
 test = [
     "coverage[toml]>=7.8.2", # Measure how much of the code is covered by tests
-    "httpx>=0.28.1",         # For the test client
-    "pytest>=8.4.0",         # Test runner
-    "pdbpp>=0.11.7",         # enables pdb++, a drop-in replacement for pdb
-    "pytest-cov>=6.2.1",     # Pytest plugin for measuring coverage.
-    "pytest-pretty>=1.3.0",  # Provides richer test session output.
+    "httpx>=0.28.1", # For the test client
+    "pytest>=8.4.0", # Test runner
+    "pdbpp>=0.11.7", # enables pdb++, a drop-in replacement for pdb
+    "pytest-cov>=6.2.1", # Pytest plugin for measuring coverage.
+    "pytest-pretty>=1.3.0", # Provides richer test session output.
+    "pytest-github-actions-annotate-failures>=0.3.0", # Pytest plugin to annotate failed tests with a workflow command for GitHub Actions
 ]
 docs = [
     "mkdocs-material",        # MkDocs theme

--- a/tests/test_applications.py
+++ b/tests/test_applications.py
@@ -6,7 +6,7 @@ import air
 
 def test_air_app_factory():
     app = air.Air()
-    assert 1==2
+
     @app.get("/test")
     def test_endpoint():
         return air.H1("Hello, World!")

--- a/tests/test_applications.py
+++ b/tests/test_applications.py
@@ -6,7 +6,7 @@ import air
 
 def test_air_app_factory():
     app = air.Air()
-
+    assert 1==2
     @app.get("/test")
     def test_endpoint():
         return air.H1("Hello, World!")

--- a/uv.lock
+++ b/uv.lock
@@ -32,6 +32,7 @@ dev = [
     { name = "pdbpp", marker = "python_full_version >= '3.13'" },
     { name = "pytest", marker = "python_full_version >= '3.13'" },
     { name = "pytest-cov", marker = "python_full_version >= '3.13'" },
+    { name = "pytest-github-actions-annotate-failures", marker = "python_full_version >= '3.13'" },
     { name = "pytest-pretty", marker = "python_full_version >= '3.13'" },
     { name = "ruff", marker = "python_full_version >= '3.13'" },
     { name = "rust-just", marker = "python_full_version >= '3.13'" },
@@ -59,6 +60,7 @@ test = [
     { name = "pdbpp" },
     { name = "pytest" },
     { name = "pytest-cov" },
+    { name = "pytest-github-actions-annotate-failures" },
     { name = "pytest-pretty" },
 ]
 
@@ -81,6 +83,7 @@ dev = [
     { name = "pdbpp", marker = "python_full_version >= '3.13'", specifier = ">=0.11.7" },
     { name = "pytest", marker = "python_full_version >= '3.13'", specifier = ">=8.4.0" },
     { name = "pytest-cov", marker = "python_full_version >= '3.13'", specifier = ">=6.2.1" },
+    { name = "pytest-github-actions-annotate-failures", marker = "python_full_version >= '3.13'", specifier = ">=0.3.0" },
     { name = "pytest-pretty", marker = "python_full_version >= '3.13'", specifier = ">=1.3.0" },
     { name = "ruff", marker = "python_full_version >= '3.13'", specifier = ">=0.11.13" },
     { name = "rust-just", marker = "python_full_version >= '3.13'", specifier = ">=1.42.3" },
@@ -108,6 +111,7 @@ test = [
     { name = "pdbpp", specifier = ">=0.11.7" },
     { name = "pytest", specifier = ">=8.4.0" },
     { name = "pytest-cov", specifier = ">=6.2.1" },
+    { name = "pytest-github-actions-annotate-failures", specifier = ">=0.3.0" },
     { name = "pytest-pretty", specifier = ">=1.3.0" },
 ]
 
@@ -1006,6 +1010,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/18/99/668cade231f434aaa59bbfbf49469068d2ddd945000621d3d165d2e7dd7b/pytest_cov-6.2.1.tar.gz", hash = "sha256:25cc6cc0a5358204b8108ecedc51a9b57b34cc6b8c967cc2c01a4e00d8a67da2", size = 69432, upload-time = "2025-06-12T10:47:47.684Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/bc/16/4ea354101abb1287856baa4af2732be351c7bee728065aed451b678153fd/pytest_cov-6.2.1-py3-none-any.whl", hash = "sha256:f5bc4c23f42f1cdd23c70b1dab1bbaef4fc505ba950d53e0081d0730dd7e86d5", size = 24644, upload-time = "2025-06-12T10:47:45.932Z" },
+]
+
+[[package]]
+name = "pytest-github-actions-annotate-failures"
+version = "0.3.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/39/d4/c54ee6a871eee4a7468e3a8c0dead28e634c0bc2110c694309dcb7563a66/pytest_github_actions_annotate_failures-0.3.0.tar.gz", hash = "sha256:d4c3177c98046c3900a7f8ddebb22ea54b9f6822201b5d3ab8fcdea51e010db7", size = 11248, upload-time = "2025-01-17T22:39:32.722Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6d/73/7b0b15cb8605ee967b34aa1d949737ab664f94e6b0f1534e8339d9e64ab2/pytest_github_actions_annotate_failures-0.3.0-py3-none-any.whl", hash = "sha256:41ea558ba10c332c0bfc053daeee0c85187507b2034e990f21e4f7e5fef044cf", size = 6030, upload-time = "2025-01-17T22:39:31.701Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
- Refined CI workflows, including better OS support, enhanced concurrency settings, and updated naming for clarity.
- Introduced annotations for failed tests using `pytest-github-actions-annotate-failures`.
- Removed outdated or redundant dependencies such as `pytest-rich` and replaced with `pytest-pretty`.
- Enhanced coverage settings by adding `ignore_errors` in `pyproject.toml` and integrating `pytest-cov` for clearer insights.
- Updated `justfile` commands for better consistency and added `test-coverage` and `test-durations` for improved testing metrics.
- Addressed test-related issues by removing incorrect assertions and improving verbosity for debug purposes.