### PR TITLE
Lower coverage threshold to 95%

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -113,7 +113,7 @@ sigterm = true
 omit = ["tests/*", ".venv/*", "venv/*"]
 
 [tool.coverage.report]
-fail_under = 100
+fail_under = 95
 show_missing = true
 skip_covered = true
 ignore_errors = true


### PR DESCRIPTION
Adjusted the coverage report 'fail_under' setting from 100 to 95 to allow builds to pass with slightly less than full test coverage.