### PR TITLE
FEAT: AirForm.validate method returns boolean instead of None

### DIFF
--- a/tests/test_forms.py
+++ b/tests/test_forms.py
@@ -224,3 +224,30 @@ def test_airform_notimplementederror():
         air.AirForm()
 
     assert "model" in str(exc.value)
+
+
+def test_airform_validate():
+    class CheeseModel(BaseModel):
+        name: str
+        age: int
+
+    class CheeseForm(air.AirForm):
+        model = CheeseModel
+
+    cheese_form = CheeseForm()
+    assert cheese_form.is_valid == False
+    cheese_form.validate({})
+    assert cheese_form.is_valid == False
+    cheese_form.validate(dict(name="Cheddar"))
+    assert cheese_form.is_valid == False
+    cheese_form.validate(dict(name="Cheddar", age=5))
+    assert cheese_form.is_valid == True
+    assert cheese_form.errors == [
+        {
+            "type": "missing",
+            "loc": ("age",),
+            "msg": "Field required",
+            "input": {"name": "Cheddar"},
+            "url": "https://errors.pydantic.dev/2.11/v/missing",
+        }
+    ]

--- a/uv.lock
+++ b/uv.lock
@@ -9,7 +9,7 @@ resolution-markers = [
 
 [[package]]
 name = "air"
-version = "0.24.0"
+version = "0.24.1"
 source = { editable = "." }
 dependencies = [
     { name = "fastapi" },


### PR DESCRIPTION
Enhanced the AirForm class to return a boolean from the validate method and updated its docstring with usage examples. Added unit tests for AirForm validation logic to ensure correct behavior.