### PR TITLE
FEAT: Performance optimisations

### DIFF
--- a/src/air/tags/config.py
+++ b/src/air/tags/config.py
@@ -11,8 +11,6 @@ HTML_ATTRIBUTES: Final[dict[str, list[str]]] = {
         "typereferrerpolicy",
         "media",
         "ping",
-        "class_",
-        "id",
     ],
     "Area": [
         "alt",
@@ -160,7 +158,6 @@ HTML_ATTRIBUTES: Final[dict[str, list[str]]] = {
     ],
     "Link": [
         "href",
-        "as_",
         "blocking",
         "crossorigin",
         "disabled",
@@ -240,7 +237,6 @@ HTML_ATTRIBUTES: Final[dict[str, list[str]]] = {
         "value",
     ],
     "Output": [
-        "for_",
         "form",
         "name",
     ],

--- a/src/air/tags/utils.py
+++ b/src/air/tags/utils.py
@@ -1,5 +1,7 @@
 """Utilities for the Air Tag system."""
 
+from functools import cache
+
 from .config import HTML_ATTRIBUTES
 
 
@@ -41,6 +43,7 @@ def locals_cleanup(local_data, obj):
     attrs = HTML_ATTRIBUTES.get(obj.__class__.__name__, [])
     attrs += ["class_", "for_", "as_", "id", "style"]
     for attr in attrs:
-        if local_data.get(attr) is not None:
+        # For performance reasons we use key checks rather than local_data.get
+        if attr in local_data and local_data[attr] is not None:
             data[attr] = local_data[attr]
     return data


### PR DESCRIPTION
pyinstrument makes it clear Tags are a bottleneck. Here's a couple optimizations

1. `data['key']` is much, MUCH faster than `data.get('key')`
2. Having unnecessary keys in the config structure adds up over time

