### PR TITLE
Override mvpcss default layout padding

### DIFF
--- a/src/air/layouts.py
+++ b/src/air/layouts.py
@@ -81,6 +81,7 @@ def mvpcss(*children, htmx: bool = True, **kwargs):
     return Html(
         Head(
             Link(rel="stylesheet", href="https://unpkg.com/mvp.css"),
+            Style("footer, header, main { padding: 1rem; }"),
             *head_tags,
         ),
         Body(

--- a/src/air/layouts.py
+++ b/src/air/layouts.py
@@ -81,7 +81,7 @@ def mvpcss(*children, htmx: bool = True, **kwargs):
     return Html(
         Head(
             Link(rel="stylesheet", href="https://unpkg.com/mvp.css"),
-            Style("footer, header, main { padding: 1rem; }"),
+            Style("footer, header, main { padding: 1rem; } nav {margin-bottom: 1rem;}"),
             *head_tags,
         ),
         Body(

--- a/tests/test_applications.py
+++ b/tests/test_applications.py
@@ -93,7 +93,7 @@ def test_air_404_response():
     assert response.headers["content-type"] == "text/html; charset=utf-8"
     assert (
         response.text
-        == '<!doctype html><html><head><link href="https://unpkg.com/mvp.css" rel="stylesheet" /><title>404 Not Found</title></head><body><main><h1>404 Not Found</h1><p>The requested resource was not found on this server.</p><p>URL: http://testserver/nonexistent</p></main></body></html>'
+        == '<!doctype html><html><head><link href="https://unpkg.com/mvp.css" rel="stylesheet" /><style>footer, header, main { padding: 1rem; }</style><title>404 Not Found</title></head><body><main><h1>404 Not Found</h1><p>The requested resource was not found on this server.</p><p>URL: http://testserver/nonexistent</p></main></body></html>'
     )
 
 
@@ -121,5 +121,5 @@ def test_default_500_exception_handler():
     assert response.headers["content-type"] == "text/html; charset=utf-8"
     assert (
         response.body
-        == b'<!doctype html><html><head><link href="https://unpkg.com/mvp.css" rel="stylesheet" /><title>500 Internal Server Error</title></head><body><main><h1>500 Internal Server Error</h1><p>An internal server error occurred.</p></main></body></html>'
+        == b'<!doctype html><html><head><link href="https://unpkg.com/mvp.css" rel="stylesheet" /><style>footer, header, main { padding: 1rem; }</style><title>500 Internal Server Error</title></head><body><main><h1>500 Internal Server Error</h1><p>An internal server error occurred.</p></main></body></html>'
     )

--- a/tests/test_applications.py
+++ b/tests/test_applications.py
@@ -93,7 +93,7 @@ def test_air_404_response():
     assert response.headers["content-type"] == "text/html; charset=utf-8"
     assert (
         response.text
-        == '<!doctype html><html><head><link href="https://unpkg.com/mvp.css" rel="stylesheet" /><style>footer, header, main { padding: 1rem; }</style><title>404 Not Found</title></head><body><main><h1>404 Not Found</h1><p>The requested resource was not found on this server.</p><p>URL: http://testserver/nonexistent</p></main></body></html>'
+        == '<!doctype html><html><head><link href="https://unpkg.com/mvp.css" rel="stylesheet" /><style>footer, header, main { padding: 1rem; } nav {margin-bottom: 1rem;}</style><title>404 Not Found</title></head><body><main><h1>404 Not Found</h1><p>The requested resource was not found on this server.</p><p>URL: http://testserver/nonexistent</p></main></body></html>'
     )
 
 
@@ -121,5 +121,5 @@ def test_default_500_exception_handler():
     assert response.headers["content-type"] == "text/html; charset=utf-8"
     assert (
         response.body
-        == b'<!doctype html><html><head><link href="https://unpkg.com/mvp.css" rel="stylesheet" /><style>footer, header, main { padding: 1rem; }</style><title>500 Internal Server Error</title></head><body><main><h1>500 Internal Server Error</h1><p>An internal server error occurred.</p></main></body></html>'
+        == b'<!doctype html><html><head><link href="https://unpkg.com/mvp.css" rel="stylesheet" /><style>footer, header, main { padding: 1rem; } nav {margin-bottom: 1rem;}</style><title>500 Internal Server Error</title></head><body><main><h1>500 Internal Server Error</h1><p>An internal server error occurred.</p></main></body></html>'
     )

--- a/tests/test_layouts.py
+++ b/tests/test_layouts.py
@@ -21,7 +21,7 @@ def test_mvpcss_layout():
     assert "<h1>Cheese Monger</h1>" in html
     assert (
         html
-        == """<!doctype html><html><head><link href="https://unpkg.com/mvp.css" rel="stylesheet" /><style>footer, header, main { padding: 1rem; }</style><script src="https://cdn.jsdelivr.net/npm/htmx.org@2.0.6/dist/htmx.min.js" integrity="sha384-Akqfrbj/HpNVo8k11SXBb6TlBWmXXlYQrCSqEWmyKJe+hDm3Z/B2WVG4smwBkRVm" crossorigin="anonymous"></script><title>Cheese Monger</title></head><body><main><h1>Cheese Monger</h1></main></body></html>"""
+        == '<!doctype html><html><head><link href="https://unpkg.com/mvp.css" rel="stylesheet" /><style>footer, header, main { padding: 1rem; } nav {margin-bottom: 1rem;}</style><script src="https://cdn.jsdelivr.net/npm/htmx.org@2.0.6/dist/htmx.min.js" integrity="sha384-Akqfrbj/HpNVo8k11SXBb6TlBWmXXlYQrCSqEWmyKJe+hDm3Z/B2WVG4smwBkRVm" crossorigin="anonymous"></script><title>Cheese Monger</title></head><body><main><h1>Cheese Monger</h1></main></body></html>'
     )
 
 
@@ -34,5 +34,5 @@ def test_mvpcss_layout_header():
     )
     assert (
         html
-        == '<!doctype html><html><head><link href="https://unpkg.com/mvp.css" rel="stylesheet" /><style>footer, header, main { padding: 1rem; }</style><script src="https://cdn.jsdelivr.net/npm/htmx.org@2.0.6/dist/htmx.min.js" integrity="sha384-Akqfrbj/HpNVo8k11SXBb6TlBWmXXlYQrCSqEWmyKJe+hDm3Z/B2WVG4smwBkRVm" crossorigin="anonymous"></script></head><body><header><h1>This is in the header</h1></header><main><p>This is in the main</p></main></body></html>'
+        == '<!doctype html><html><head><link href="https://unpkg.com/mvp.css" rel="stylesheet" /><style>footer, header, main { padding: 1rem; } nav {margin-bottom: 1rem;}</style><script src="https://cdn.jsdelivr.net/npm/htmx.org@2.0.6/dist/htmx.min.js" integrity="sha384-Akqfrbj/HpNVo8k11SXBb6TlBWmXXlYQrCSqEWmyKJe+hDm3Z/B2WVG4smwBkRVm" crossorigin="anonymous"></script></head><body><header><h1>This is in the header</h1></header><main><p>This is in the main</p></main></body></html>'
     )

--- a/tests/test_layouts.py
+++ b/tests/test_layouts.py
@@ -21,7 +21,7 @@ def test_mvpcss_layout():
     assert "<h1>Cheese Monger</h1>" in html
     assert (
         html
-        == """<!doctype html><html><head><link href="https://unpkg.com/mvp.css" rel="stylesheet" /><script src="https://cdn.jsdelivr.net/npm/htmx.org@2.0.6/dist/htmx.min.js" integrity="sha384-Akqfrbj/HpNVo8k11SXBb6TlBWmXXlYQrCSqEWmyKJe+hDm3Z/B2WVG4smwBkRVm" crossorigin="anonymous"></script><title>Cheese Monger</title></head><body><main><h1>Cheese Monger</h1></main></body></html>"""
+        == """<!doctype html><html><head><link href="https://unpkg.com/mvp.css" rel="stylesheet" /><style>footer, header, main { padding: 1rem; }</style><script src="https://cdn.jsdelivr.net/npm/htmx.org@2.0.6/dist/htmx.min.js" integrity="sha384-Akqfrbj/HpNVo8k11SXBb6TlBWmXXlYQrCSqEWmyKJe+hDm3Z/B2WVG4smwBkRVm" crossorigin="anonymous"></script><title>Cheese Monger</title></head><body><main><h1>Cheese Monger</h1></main></body></html>"""
     )
 
 
@@ -34,5 +34,5 @@ def test_mvpcss_layout_header():
     )
     assert (
         html
-        == '<!doctype html><html><head><link href="https://unpkg.com/mvp.css" rel="stylesheet" /><script src="https://cdn.jsdelivr.net/npm/htmx.org@2.0.6/dist/htmx.min.js" integrity="sha384-Akqfrbj/HpNVo8k11SXBb6TlBWmXXlYQrCSqEWmyKJe+hDm3Z/B2WVG4smwBkRVm" crossorigin="anonymous"></script></head><body><header><h1>This is in the header</h1></header><main><p>This is in the main</p></main></body></html>'
+        == '<!doctype html><html><head><link href="https://unpkg.com/mvp.css" rel="stylesheet" /><style>footer, header, main { padding: 1rem; }</style><script src="https://cdn.jsdelivr.net/npm/htmx.org@2.0.6/dist/htmx.min.js" integrity="sha384-Akqfrbj/HpNVo8k11SXBb6TlBWmXXlYQrCSqEWmyKJe+hDm3Z/B2WVG4smwBkRVm" crossorigin="anonymous"></script></head><body><header><h1>This is in the header</h1></header><main><p>This is in the main</p></main></body></html>'
     )


### PR DESCRIPTION
Fixes https://github.com/feldroy/air/issues/333

By default, [mvpcss](https://unpkg.com/mvp.css@1.17.2/mvp.css) applies the following padding to the `header`, `main`, and `footer` blocks:

```css
footer,
header,
main {
  margin: 0 auto;
  max-width: var(--width-content);
  padding: 3rem 1rem;
}
```

I’ve overridden the padding and reduced it to `1rem`.