### PR TITLE
FEAT: add login management

### DIFF
--- a/examples/login.py
+++ b/examples/login.py
@@ -1,0 +1,53 @@
+from fastapi import Depends
+import air
+
+app = air.Air()
+app.add_middleware(air.SessionMiddleware, secret_key="change-me")
+
+login_manager = air.LoginManager(login_url="/login")
+
+
+@login_manager.user_loader
+def load_user(user_id: str):
+    # Replace with real DB lookup
+    if user_id == "42":
+        return {"id": 42, "name": "Alice"}
+    return None
+
+
+@app.get("/login")
+async def login_page():
+    # Example login page
+    return air.layouts.mvpcss(
+        air.H1("Login"),
+        air.Form(
+            air.Input(type="text", name="username"),
+            air.Input(type="password", name="password"),
+            air.Button("Login"),
+            action="/do-login",
+            method="post"
+        ),
+    )
+
+
+@app.post("/do-login")
+async def do_login(request: air.Request):
+    # Example login logic
+    form = await request.form()
+    user_id = "42"  # hardcoded for example
+    return await login_manager.login_user(request, user_id, redirect_url="/")
+
+
+@app.get("/")
+async def index(user=Depends(login_manager)):
+    # If user not logged in, they get redirected
+    return air.layouts.mvpcss(
+        air.H1(f"Hello {user['name']}!"),
+        air.A("Logout", href="/logout")
+    )
+
+
+@app.get("/logout")
+async def do_login(request: air.Request):
+    await login_manager.logout_user(request)
+    return air.RedirectResponse(url="/", status_code=302)

--- a/src/air/__init__.py
+++ b/src/air/__init__.py
@@ -9,6 +9,7 @@ from .forms import AirField as AirField, AirForm as AirForm
 from .middleware import SessionMiddleware as SessionMiddleware
 from .requests import Request as Request
 from .dependencies import is_htmx_request as is_htmx_request
+from .login import LoginManager as LoginManager
 from .responses import (
     AirResponse as AirResponse,
     SSEResponse as SSEResponse,

--- a/src/air/login.py
+++ b/src/air/login.py
@@ -1,0 +1,147 @@
+from typing import Any, Callable
+from urllib.parse import quote
+
+from fastapi import HTTPException, Depends
+from .requests import Request
+from .responses import RedirectResponse
+
+
+class LoginManager:
+    """User login management for air routes
+
+    This class provides login, logout, and dependency-based authentication
+    similar to Flask-Login and Microdot. It stores the user ID
+    in the session and redirects unauthenticated users to a login page.
+
+    Example:
+
+        from fastapi import FastAPI, Depends
+        import air
+
+        app = air.Air()
+        app.add_middleware(air.SessionMiddleware, secret_key="change-me")
+
+        manager = air.LoginManager(login_url="/login")
+
+        # Register user loader callback
+        @manager.user_loader
+        def load_user(user_id: str):
+            # Replace with real DB lookup
+            if user_id == "42":
+                return {"id": 42, "name": "Alice"}
+            return None
+
+        @app.get("/login")
+        async def login_page():
+            # Example login page
+            return air.layouts.mvpcss(
+                air.H1("Login"),
+                air.Form(action="/do-login", method="post")(
+                    air.Input(type="text", name="username"),
+                    air.Input(type="password", name="password"),
+                    air.Button("Login")
+                ),
+            )
+
+        @app.post("/do-login")
+        async def do_login(request: Request):
+            # Example login logic
+            form = await request.form()
+            user_id = "42"  # hardcoded for example
+            return await manager.login_user(request, user_id, redirect_url="/")
+
+        @app.get("/")
+        async def index(user=Depends(manager)):
+            # If user not logged in, they get redirected
+            return air.layouts.mvpcss(
+                air.H1(f"Hello {user['name']}!"),
+                air.A("Logout", href="/logout")
+            )
+    """
+
+    USER_KEY = "_user_id"
+
+    def __init__(self, login_url: str = '/login'):
+        """Initialize the login manager.
+
+        Args:
+            login_url: The URL path to redirect unauthenticated users.
+                       Defaults to ``/login``.
+        """
+        self.login_url = login_url
+        self._load_user: Callable[[str], Any] | None = None
+
+    def user_loader(self, callback: Callable[[str], Any]):
+        """Register a function to load a user by ID.
+
+        The callback should take a user ID string and return a user object,
+        or ``None`` if the user does not exist.
+        """
+        self._load_user = callback
+
+    async def login_user(self, request: Request, user_id: str, redirect_url: str = '/'):
+        """Log a user in and redirect.
+
+        Args:
+            request: The current request.
+            user_id: The ID of the user to store in the session.
+            redirect_url: Default redirect path if no ``next`` parameter
+                          is present in the request. Defaults to ``/``.
+
+        Returns:
+            RedirectResponse to the next URL or the default redirect.
+        """
+        session = self._get_session(request)
+        session[self.USER_KEY] = user_id
+
+        next_url = request.query_params.get('next', redirect_url)
+        if not next_url.startswith('/'):
+            next_url = redirect_url
+        return RedirectResponse(next_url, status_code=302)
+
+    async def logout_user(self, request: Request):
+        """Log out the current user by clearing the session."""
+        session = self._get_session(request)
+        session.pop(self.USER_KEY, None)
+
+    def _get_session(self, request: Request) -> dict:
+        """Return the session dict or raise error if SessionMiddleware is missing."""
+        assert "session" in request.scope, "SessionMiddleware must be installed to use LoginManager"
+        return request.session
+
+    def _redirect_to_login(self, request: Request):
+        """Raise an HTTPException redirecting to the login page.
+
+        The current request URL is added as a ``next`` parameter.
+        """
+        raise HTTPException(
+            status_code=302,
+            headers={
+                "Location": f"{self.login_url}?next={quote(str(request.url.path))}"
+            }
+        )
+
+    async def __call__(self, request: Request) -> Any:
+        """Dependency entry point for retrieving the current user.
+
+        This makes ``LoginManager`` usable with ``Depends`` in FastAPI.
+
+        Args:
+            request: The incoming request, provided automatically by FastAPI.
+
+        Returns:
+            The user object loaded by the registered ``user_loader``.
+
+        Raises:
+            HTTPException: Redirect to the login page if no user is found.
+        """
+        session = self._get_session(request)
+        user_id = session.get(self.USER_KEY)
+        if not user_id:
+            self._redirect_to_login(request)
+
+        user = self._load_user(user_id)
+        if not user:
+            self._redirect_to_login(request)
+
+        return user


### PR DESCRIPTION
Fixes [https://github.com/feldroy/air/issues/225](https://github.com/feldroy/air/issues/225)

This PR introduces an initial draft of login management for the Air framework.
The design takes inspiration from Microdot’s [login management](https://github.com/miguelgrinberg/microdot/blob/main/src/microdot/login.py) and [FastAPI Login](https://github.com/maxrdu/fastapi_login/tree/master/fastapi_login), as suggested in related issue.

I’d appreciate it if you could review the approach and let me know whether it’s heading in the right direction. Feedback would be very helpful so I can refine the implementation, improve the example and add some tests.
@pydanny
