### PR TITLE
Add includes argument to AirForm rendering

### DIFF
--- a/src/air/forms.py
+++ b/src/air/forms.py
@@ -134,7 +134,7 @@ def errors_to_dict(errors: list[dict] | None) -> dict[str, dict]:
 
 
 def default_form_widget(
-    model: type[BaseModel], data: dict | None = None, errors: list | None = None, includes: list | None = None
+    model: type[BaseModel], data: dict | None = None, errors: list | None = None, includes: Sequence[str] | None = None
 ) -> str:
     error_dict = errors_to_dict(errors)
     fields = []

--- a/src/air/forms.py
+++ b/src/air/forms.py
@@ -2,7 +2,7 @@
 
 Pro-tip: Always validate incoming data."""
 
-from collections.abc import Callable
+from collections.abc import Callable, Sequence
 from types import UnionType
 from typing import Any, Union, get_args, get_origin
 
@@ -58,6 +58,7 @@ class AirForm:
     initial_data: dict | None = None
     errors: list[ErrorDetails] | None = None
     is_valid: bool = False
+    includes: Sequence[str] | None = None
 
     def __init__(self, initial_data: dict | None = None):
         if self.model is None:
@@ -97,7 +98,9 @@ class AirForm:
         return default_form_widget
 
     def render(self) -> tags.SafeStr:
-        return tags.SafeStr(self.widget(model=self.model, data=self.initial_data, errors=self.errors))
+        return tags.SafeStr(
+            self.widget(model=self.model, data=self.initial_data, errors=self.errors, includes=self.includes)
+        )
 
 
 def pydantic_type_to_html_type(field_info: Any) -> str:
@@ -130,10 +133,14 @@ def errors_to_dict(errors: list[dict] | None) -> dict[str, dict]:
     return {error["loc"][0]: error for error in errors}
 
 
-def default_form_widget(model: type[BaseModel], data: dict | None = None, errors: list | None = None) -> str:
+def default_form_widget(
+    model: type[BaseModel], data: dict | None = None, errors: list | None = None, includes: list | None = None
+) -> str:
     error_dict = errors_to_dict(errors)
     fields = []
     for field_name, field_info in model.model_fields.items():
+        if includes is not None and field_name not in includes:
+            continue
         field_type = field_info.annotation
         origin = get_origin(field_type)
 

--- a/tests/test_forms.py
+++ b/tests/test_forms.py
@@ -276,3 +276,26 @@ def test_air_field_json_schema_extra():
     html = CheeseForm().render()
     assert '<input name="name" type="text" autofocus id="name" />' in html
     assert '<label for="age">my-age</label>' in html
+
+
+def test_field_includes():
+    class PlaneModel(BaseModel):
+        id: int
+        name: str
+        year_released: int
+        max_airspeed: str
+
+    # Control test - make sure existing system still works
+    class PlaneForm(air.AirForm):
+        model = PlaneModel
+
+    html = PlaneForm().render()
+    assert '<label for="id">id</label><input name="id" type="number" id="id" />' in html
+
+    # Test with includes active, removing id field
+    class PlaneForm(air.AirForm):
+        model = PlaneModel
+        includes = ("name", "year_released", "max_airspeed")
+
+    html = PlaneForm().render()
+    assert '<label for="id">id</label><input name="id" type="number" id="id" />' not in html


### PR DESCRIPTION
For #372 introduces an 'includes' attribute to AirForm, allowing selective rendering of model fields in forms. Updates default_form_widget and render logic to respect the 'includes' sequence. Adds tests to verify correct behavior when 'includes' is set.