### PR TITLE
Add Renderable type alias

### DIFF
--- a/src/air/__init__.py
+++ b/src/air/__init__.py
@@ -24,6 +24,7 @@ from .responses import (
 )
 from .routing import AirRouter as AirRouter
 from .tags import (
+    Renderable as Renderable,
     H1 as H1,
     H2 as H2,
     H3 as H3,

--- a/src/air/__init__.py
+++ b/src/air/__init__.py
@@ -24,7 +24,6 @@ from .responses import (
 )
 from .routing import AirRouter as AirRouter
 from .tags import (
-    Renderable as Renderable,
     H1 as H1,
     H2 as H2,
     H3 as H3,
@@ -105,6 +104,7 @@ from .tags import (
     Progress as Progress,
     Q as Q,
     Raw as Raw,
+    Renderable as Renderable,
     Rp as Rp,
     Rt as Rt,
     Ruby as Ruby,

--- a/src/air/layouts.py
+++ b/src/air/layouts.py
@@ -15,6 +15,7 @@ from .tags import (
     Tag,
     Title,
 )
+from .tags.models.base import Renderable
 
 HEAD_TAG_TYPES: tuple[type[Tag], ...] = (Title, Style, Meta, Link, Script, Base)
 
@@ -37,7 +38,7 @@ def _header(tags) -> Header | str:
     return ""
 
 
-def mvpcss(*children, is_htmx: bool = False, **kwargs):
+def mvpcss(*children: Renderable, is_htmx: bool = False, **kwargs):
     """Renders the basic layout with MVP.css and HTMX for quick prototyping
 
     1. At the top level HTML head tags are put in the `<head>` tag
@@ -106,7 +107,7 @@ def mvpcss(*children, is_htmx: bool = False, **kwargs):
     ).render()
 
 
-def picocss(*children, is_htmx: bool = False, **kwargs):
+def picocss(*children: Renderable, is_htmx: bool = False, **kwargs):
     """Renders the basic layout with PicoCSS and HTMX for quick prototyping
 
     1. At the top level HTML head tags are put in the `<head>` tag

--- a/src/air/tags/__init__.py
+++ b/src/air/tags/__init__.py
@@ -1,6 +1,7 @@
 __doc__ = """Easy to write and performant HTML content generation using Python classes to render HTML."""
 
 from .models import (
+    Renderable as Renderable,
     H1 as H1,
     H2 as H2,
     H3 as H3,

--- a/src/air/tags/__init__.py
+++ b/src/air/tags/__init__.py
@@ -1,7 +1,6 @@
 __doc__ = """Easy to write and performant HTML content generation using Python classes to render HTML."""
 
 from .models import (
-    Renderable as Renderable,
     H1 as H1,
     H2 as H2,
     H3 as H3,
@@ -82,6 +81,7 @@ from .models import (
     Progress as Progress,
     Q as Q,
     Raw as Raw,
+    Renderable as Renderable,
     Rp as Rp,
     Rt as Rt,
     Ruby as Ruby,

--- a/src/air/tags/models/__init__.py
+++ b/src/air/tags/models/__init__.py
@@ -1,4 +1,5 @@
 from . import svg as svg
+from .base import Renderable as Renderable
 from .special import (
     Children as Children,
     Html as Html,

--- a/src/air/tags/models/base.py
+++ b/src/air/tags/models/base.py
@@ -2,10 +2,9 @@
 
 import html
 from functools import cached_property
-from typing import Any, Union
+from typing import Union
 
 from ..utils import SafeStr, clean_html_attr_key
-
 
 # Type hint for renderable content
 # Excludes types like None (renders as "None"), bool ("True"/"False"),

--- a/src/air/tags/models/base.py
+++ b/src/air/tags/models/base.py
@@ -2,9 +2,13 @@
 
 import html
 from functools import cached_property
-from typing import Any
+from typing import Any, Union
 
 from ..utils import SafeStr, clean_html_attr_key
+
+
+# Type hint for renderable content
+Renderable = Union[str, "Tag", SafeStr]
 
 
 class Tag:
@@ -18,7 +22,7 @@ class Tag:
 
     self_closing = False
 
-    def __init__(self, *children: Any, **kwargs: str | int | float | bool):
+    def __init__(self, *children: Renderable, **kwargs: str | int | float | bool):
         """
         Args:
             children: Tags, strings, or other rendered content.
@@ -26,6 +30,8 @@ class Tag:
         """
         self._name = self.__class__.__name__
         self._module = self.__class__.__module__
+        self._children: tuple[Renderable, ...]
+        self._attrs: dict[str, str | int | float | bool]
         self._children, self._attrs = children, kwargs
 
     @property

--- a/src/air/tags/models/base.py
+++ b/src/air/tags/models/base.py
@@ -8,7 +8,10 @@ from ..utils import SafeStr, clean_html_attr_key
 
 
 # Type hint for renderable content
-Renderable = Union[str, "Tag", SafeStr]
+# Excludes types like None (renders as "None"), bool ("True"/"False"),
+# complex ("(1+2j)"), bytes ("b'...'"), and others that produce
+# undesirable or unintended HTML output.
+Renderable = Union[str, "Tag", SafeStr, int, float]
 
 
 class Tag:

--- a/src/air/tags/models/special.py
+++ b/src/air/tags/models/special.py
@@ -56,7 +56,7 @@ class Raw(Tag):
 
     def render(self) -> str:
         """Render the string without escaping."""
-        return self._children[0] if self._children else ""
+        return str(self._children[0]) if self._children else ""
 
 
 class NoEscapeTag(Tag):

--- a/src/air/tags/models/stock.py
+++ b/src/air/tags/models/stock.py
@@ -5,7 +5,7 @@ Script and Style tags can be found in the [air.tags.models.special](/reference/a
 from typing import Any
 
 from ..utils import locals_cleanup
-from .base import Tag
+from .base import Tag, Renderable
 
 
 class A(Tag):
@@ -955,7 +955,7 @@ class Form(Tag):
 
     def __init__(
         self,
-        *children: Any,
+        *children: Renderable,
         action: str | None = None,
         method: str | None = None,
         accept_charset: str | None = None,

--- a/src/air/tags/models/stock.py
+++ b/src/air/tags/models/stock.py
@@ -30,7 +30,7 @@ class A(Tag):
 
     def __init__(
         self,
-        *children: Any,
+        *children: Renderable,
         href: str | None = None,
         target: str | None = None,
         download: str | None = None,
@@ -61,7 +61,7 @@ class Abbr(Tag):
 
     def __init__(
         self,
-        *children: Any,
+        *children: Renderable,
         class_: str | None = None,
         id: str | None = None,
         style: str | None = None,
@@ -83,7 +83,7 @@ class Address(Tag):
 
     def __init__(
         self,
-        *children: Any,
+        *children: Renderable,
         class_: str | None = None,
         id: str | None = None,
         style: str | None = None,
@@ -114,7 +114,7 @@ class Area(Tag):
 
     def __init__(
         self,
-        *children: Any,
+        *children: Renderable,
         alt: str | None = None,
         coords: str | None = None,
         download: str | None = None,
@@ -146,7 +146,7 @@ class Article(Tag):
 
     def __init__(
         self,
-        *children: Any,
+        *children: Renderable,
         class_: str | None = None,
         id: str | None = None,
         style: str | None = None,
@@ -168,7 +168,7 @@ class Aside(Tag):
 
     def __init__(
         self,
-        *children: Any,
+        *children: Renderable,
         class_: str | None = None,
         id: str | None = None,
         style: str | None = None,
@@ -196,7 +196,7 @@ class Audio(Tag):
 
     def __init__(
         self,
-        *children: Any,
+        *children: Renderable,
         autoplay: str | None = None,
         controls: str | None = None,
         loop: str | None = None,
@@ -224,7 +224,7 @@ class B(Tag):
 
     def __init__(
         self,
-        *children: Any,
+        *children: Renderable,
         class_: str | None = None,
         id: str | None = None,
         style: str | None = None,
@@ -246,7 +246,7 @@ class Base(Tag):
 
     def __init__(
         self,
-        *children: Any,
+        *children: Renderable,
         href: str | None = None,
         target: str | None = None,
         class_: str | None = None,
@@ -271,7 +271,7 @@ class Bdi(Tag):
 
     def __init__(
         self,
-        *children: Any,
+        *children: Renderable,
         class_: str | None = None,
         id: str | None = None,
         style: str | None = None,
@@ -294,7 +294,7 @@ class Bdo(Tag):
 
     def __init__(
         self,
-        *children: Any,
+        *children: Renderable,
         dir: str | None = None,
         class_: str | None = None,
         id: str | None = None,
@@ -318,7 +318,7 @@ class Blockquote(Tag):
 
     def __init__(
         self,
-        *children: Any,
+        *children: Renderable,
         cite: str | None = None,
         class_: str | None = None,
         id: str | None = None,
@@ -338,7 +338,7 @@ class Body(Tag):
 
     def __init__(
         self,
-        *children: Any,
+        *children: Renderable,
         **kwargs: str | float | int | bool,
     ):
         super().__init__(*children, **kwargs | locals_cleanup(locals()))
@@ -357,7 +357,7 @@ class Br(Tag):
 
     def __init__(
         self,
-        *children: Any,
+        *children: Renderable,
         class_: str | None = None,
         id: str | None = None,
         style: str | None = None,
@@ -393,7 +393,7 @@ class Button(Tag):
 
     def __init__(
         self,
-        *children: Any,
+        *children: Renderable,
         name: str | None = None,
         type: str | None = None,
         value: str | None = None,
@@ -430,7 +430,7 @@ class Canvas(Tag):
 
     def __init__(
         self,
-        *children: Any,
+        *children: Renderable,
         width: str | int | None = None,
         height: str | int | None = None,
         class_: str | None = None,
@@ -454,7 +454,7 @@ class Caption(Tag):
 
     def __init__(
         self,
-        *children: Any,
+        *children: Renderable,
         class_: str | None = None,
         id: str | None = None,
         style: str | None = None,
@@ -476,7 +476,7 @@ class Cite(Tag):
 
     def __init__(
         self,
-        *children: Any,
+        *children: Renderable,
         class_: str | None = None,
         id: str | None = None,
         style: str | None = None,
@@ -498,7 +498,7 @@ class Code(Tag):
 
     def __init__(
         self,
-        *children: Any,
+        *children: Renderable,
         class_: str | None = None,
         id: str | None = None,
         style: str | None = None,
@@ -521,7 +521,7 @@ class Col(Tag):
 
     def __init__(
         self,
-        *children: Any,
+        *children: Renderable,
         span: str | None = None,
         class_: str | None = None,
         id: str | None = None,
@@ -546,7 +546,7 @@ class Colgroup(Tag):
 
     def __init__(
         self,
-        *children: Any,
+        *children: Renderable,
         span: str | None = None,
         class_: str | None = None,
         id: str | None = None,
@@ -570,7 +570,7 @@ class Data(Tag):
 
     def __init__(
         self,
-        *children: Any,
+        *children: Renderable,
         value: str | None = None,
         class_: str | None = None,
         id: str | None = None,
@@ -593,7 +593,7 @@ class Datalist(Tag):
 
     def __init__(
         self,
-        *children: Any,
+        *children: Renderable,
         class_: str | None = None,
         id: str | None = None,
         style: str | None = None,
@@ -617,7 +617,7 @@ class Dd(Tag):
 
     def __init__(
         self,
-        *children: Any,
+        *children: Renderable,
         cite: str | None = None,
         datetime: str | None = None,
         class_: str | None = None,
@@ -641,7 +641,7 @@ class Del(Tag):
 
     def __init__(
         self,
-        *children: Any,
+        *children: Renderable,
         class_: str | None = None,
         id: str | None = None,
         style: str | None = None,
@@ -664,7 +664,7 @@ class Details(Tag):
 
     def __init__(
         self,
-        *children: Any,
+        *children: Renderable,
         open: str | None = None,
         class_: str | None = None,
         id: str | None = None,
@@ -687,7 +687,7 @@ class Dfn(Tag):
 
     def __init__(
         self,
-        *children: Any,
+        *children: Renderable,
         class_: str | None = None,
         id: str | None = None,
         style: str | None = None,
@@ -710,7 +710,7 @@ class Dialog(Tag):
 
     def __init__(
         self,
-        *children: Any,
+        *children: Renderable,
         open: str | None = None,
         class_: str | None = None,
         id: str | None = None,
@@ -733,7 +733,7 @@ class Div(Tag):
 
     def __init__(
         self,
-        *children: Any,
+        *children: Renderable,
         class_: str | None = None,
         id: str | None = None,
         style: str | None = None,
@@ -755,7 +755,7 @@ class Dl(Tag):
 
     def __init__(
         self,
-        *children: Any,
+        *children: Renderable,
         class_: str | None = None,
         id: str | None = None,
         style: str | None = None,
@@ -777,7 +777,7 @@ class Dt(Tag):
 
     def __init__(
         self,
-        *children: Any,
+        *children: Renderable,
         class_: str | None = None,
         id: str | None = None,
         style: str | None = None,
@@ -799,7 +799,7 @@ class Em(Tag):
 
     def __init__(
         self,
-        *children: Any,
+        *children: Renderable,
         class_: str | None = None,
         id: str | None = None,
         style: str | None = None,
@@ -825,7 +825,7 @@ class Embed(Tag):
 
     def __init__(
         self,
-        *children: Any,
+        *children: Renderable,
         src: str | None = None,
         type: str | None = None,
         width: str | int | None = None,
@@ -855,7 +855,7 @@ class Fieldset(Tag):
 
     def __init__(
         self,
-        *children: Any,
+        *children: Renderable,
         disabled: str | None = None,
         form: str | None = None,
         name: str | None = None,
@@ -880,7 +880,7 @@ class Figcaption(Tag):
 
     def __init__(
         self,
-        *children: Any,
+        *children: Renderable,
         class_: str | None = None,
         id: str | None = None,
         style: str | None = None,
@@ -902,7 +902,7 @@ class Figure(Tag):
 
     def __init__(
         self,
-        *children: Any,
+        *children: Renderable,
         class_: str | None = None,
         id: str | None = None,
         style: str | None = None,
@@ -924,7 +924,7 @@ class Footer(Tag):
 
     def __init__(
         self,
-        *children: Any,
+        *children: Renderable,
         class_: str | None = None,
         id: str | None = None,
         style: str | None = None,
@@ -986,7 +986,7 @@ class H1(Tag):
 
     def __init__(
         self,
-        *children: Any,
+        *children: Renderable,
         class_: str | None = None,
         id: str | None = None,
         style: str | None = None,
@@ -1008,7 +1008,7 @@ class H2(Tag):
 
     def __init__(
         self,
-        *children: Any,
+        *children: Renderable,
         class_: str | None = None,
         id: str | None = None,
         style: str | None = None,
@@ -1030,7 +1030,7 @@ class H3(Tag):
 
     def __init__(
         self,
-        *children: Any,
+        *children: Renderable,
         class_: str | None = None,
         id: str | None = None,
         style: str | None = None,
@@ -1052,7 +1052,7 @@ class H4(Tag):
 
     def __init__(
         self,
-        *children: Any,
+        *children: Renderable,
         class_: str | None = None,
         id: str | None = None,
         style: str | None = None,
@@ -1074,7 +1074,7 @@ class H5(Tag):
 
     def __init__(
         self,
-        *children: Any,
+        *children: Renderable,
         class_: str | None = None,
         id: str | None = None,
         style: str | None = None,
@@ -1096,7 +1096,7 @@ class H6(Tag):
 
     def __init__(
         self,
-        *children: Any,
+        *children: Renderable,
         class_: str | None = None,
         id: str | None = None,
         style: str | None = None,
@@ -1116,7 +1116,7 @@ class Head(Tag):
 
     def __init__(
         self,
-        *children: Any,
+        *children: Renderable,
         profile: str | None = None,
         **kwargs: str | float | int | bool,
     ):
@@ -1136,7 +1136,7 @@ class Header(Tag):
 
     def __init__(
         self,
-        *children: Any,
+        *children: Renderable,
         class_: str | None = None,
         id: str | None = None,
         style: str | None = None,
@@ -1158,7 +1158,7 @@ class Hgroup(Tag):
 
     def __init__(
         self,
-        *children: Any,
+        *children: Renderable,
         class_: str | None = None,
         id: str | None = None,
         style: str | None = None,
@@ -1180,7 +1180,7 @@ class Hr(Tag):
 
     def __init__(
         self,
-        *children: Any,
+        *children: Renderable,
         class_: str | None = None,
         id: str | None = None,
         style: str | None = None,
@@ -1203,7 +1203,7 @@ class I(Tag):  # noqa: E742
 
     def __init__(
         self,
-        *children: Any,
+        *children: Renderable,
         class_: str | None = None,
         id: str | None = None,
         style: str | None = None,
@@ -1236,7 +1236,7 @@ class Iframe(Tag):
 
     def __init__(
         self,
-        *children: Any,
+        *children: Renderable,
         src: str | None = None,
         srcdoc: str | None = None,
         width: str | int | None = None,
@@ -1281,7 +1281,7 @@ class Img(Tag):
 
     def __init__(
         self,
-        *children: Any,
+        *children: Renderable,
         src: str | None = None,
         width: str | int | None = None,
         height: str | int | None = None,
@@ -1348,7 +1348,7 @@ class Input(Tag):
 
     def __init__(
         self,
-        *children: Any,
+        *children: Renderable,
         name: str | None = None,
         type: str | None = None,
         value: str | None = None,
@@ -1405,7 +1405,7 @@ class Ins(Tag):
 
     def __init__(
         self,
-        *children: Any,
+        *children: Renderable,
         cite: str | None = None,
         datetime: str | None = None,
         class_: str | None = None,
@@ -1429,7 +1429,7 @@ class Kbd(Tag):
 
     def __init__(
         self,
-        *children: Any,
+        *children: Renderable,
         class_: str | None = None,
         id: str | None = None,
         style: str | None = None,
@@ -1452,7 +1452,7 @@ class Label(Tag):
 
     def __init__(
         self,
-        *children: Any,
+        *children: Renderable,
         for_: str | None = None,
         class_: str | None = None,
         id: str | None = None,
@@ -1475,7 +1475,7 @@ class Legend(Tag):
 
     def __init__(
         self,
-        *children: Any,
+        *children: Renderable,
         class_: str | None = None,
         id: str | None = None,
         style: str | None = None,
@@ -1498,7 +1498,7 @@ class Li(Tag):
 
     def __init__(
         self,
-        *children: Any,
+        *children: Renderable,
         value: int | None = None,
         class_: str | None = None,
         id: str | None = None,
@@ -1536,7 +1536,7 @@ class Link(Tag):
 
     def __init__(
         self,
-        *children: Any,
+        *children: Renderable,
         href: str | None = None,
         as_: str | None = None,
         blocking: str | None = None,
@@ -1574,7 +1574,7 @@ class Main(Tag):
 
     def __init__(
         self,
-        *children: Any,
+        *children: Renderable,
         class_: str | None = None,
         id: str | None = None,
         style: str | None = None,
@@ -1597,7 +1597,7 @@ class Map(Tag):
 
     def __init__(
         self,
-        *children: Any,
+        *children: Renderable,
         name: str | None = None,
         class_: str | None = None,
         id: str | None = None,
@@ -1620,7 +1620,7 @@ class Mark(Tag):
 
     def __init__(
         self,
-        *children: Any,
+        *children: Renderable,
         class_: str | None = None,
         id: str | None = None,
         style: str | None = None,
@@ -1643,7 +1643,7 @@ class Menu(Tag):
 
     def __init__(
         self,
-        *children: Any,
+        *children: Renderable,
         compact: str | None = None,
         class_: str | None = None,
         id: str | None = None,
@@ -1671,7 +1671,7 @@ class Meta(Tag):
 
     def __init__(
         self,
-        *children: Any,
+        *children: Renderable,
         charset: str | None = None,
         content: str | None = None,
         http_equiv: str | None = None,
@@ -1704,7 +1704,7 @@ class Meter(Tag):
 
     def __init__(
         self,
-        *children: Any,
+        *children: Renderable,
         value: str | None = None,
         min: str | None = None,
         max: str | None = None,
@@ -1732,7 +1732,7 @@ class Nav(Tag):
 
     def __init__(
         self,
-        *children: Any,
+        *children: Renderable,
         class_: str | None = None,
         id: str | None = None,
         style: str | None = None,
@@ -1753,7 +1753,7 @@ class Noscript(Tag):
 
     def __init__(
         self,
-        *children: Any,
+        *children: Renderable,
         class_: str | None = None,
         id: str | None = None,
         **kwargs: str | float | int | bool,
@@ -1787,7 +1787,7 @@ class Object(Tag):
 
     def __init__(
         self,
-        *children: Any,
+        *children: Renderable,
         archive: str | None = None,
         border: str | None = None,
         classid: str | None = None,
@@ -1827,7 +1827,7 @@ class Ol(Tag):
 
     def __init__(
         self,
-        *children: Any,
+        *children: Renderable,
         compact: str | None = None,
         reversed: str | None = None,
         start: str | None = None,
@@ -1855,7 +1855,7 @@ class Optgroup(Tag):
 
     def __init__(
         self,
-        *children: Any,
+        *children: Renderable,
         disabled: str | None = None,
         label: str | None = None,
         class_: str | None = None,
@@ -1883,7 +1883,7 @@ class Option(Tag):
 
     def __init__(
         self,
-        *children: Any,
+        *children: Renderable,
         disabled: str | None = None,
         label: str | None = None,
         selected: bool | None = None,
@@ -1912,7 +1912,7 @@ class Output(Tag):
 
     def __init__(
         self,
-        *children: Any,
+        *children: Renderable,
         for_: str | None = None,
         form: str | None = None,
         name: str | None = None,
@@ -1937,7 +1937,7 @@ class P(Tag):
 
     def __init__(
         self,
-        *children: Any,
+        *children: Renderable,
         class_: str | None = None,
         id: str | None = None,
         style: str | None = None,
@@ -1958,7 +1958,7 @@ class Param(Tag):
 
     def __init__(
         self,
-        *children: Any,
+        *children: Renderable,
         class_: str | None = None,
         id: str | None = None,
         **kwargs: str | float | int | bool,
@@ -1972,7 +1972,7 @@ class Picture(Tag):
 
     def __init__(
         self,
-        *children: Any,
+        *children: Renderable,
         class_: str | None = None,
         id: str | None = None,
         style: str | None = None,
@@ -1986,7 +1986,7 @@ class Pre(Tag):
 
     def __init__(
         self,
-        *children: Any,
+        *children: Renderable,
         width: str | int | None = None,
         wrap: str | None = None,
         class_: str | None = None,
@@ -2002,7 +2002,7 @@ class Progress(Tag):
 
     def __init__(
         self,
-        *children: Any,
+        *children: Renderable,
         max: str | None = None,
         value: str | None = None,
         class_: str | None = None,
@@ -2018,7 +2018,7 @@ class Q(Tag):
 
     def __init__(
         self,
-        *children: Any,
+        *children: Renderable,
         cite: str | None = None,
         class_: str | None = None,
         id: str | None = None,
@@ -2033,7 +2033,7 @@ class Rp(Tag):
 
     def __init__(
         self,
-        *children: Any,
+        *children: Renderable,
         class_: str | None = None,
         id: str | None = None,
         **kwargs: str | float | int | bool,
@@ -2046,7 +2046,7 @@ class Rt(Tag):
 
     def __init__(
         self,
-        *children: Any,
+        *children: Renderable,
         class_: str | None = None,
         id: str | None = None,
         **kwargs: str | float | int | bool,
@@ -2059,7 +2059,7 @@ class Ruby(Tag):
 
     def __init__(
         self,
-        *children: Any,
+        *children: Renderable,
         class_: str | None = None,
         id: str | None = None,
         **kwargs: str | float | int | bool,
@@ -2072,7 +2072,7 @@ class S(Tag):
 
     def __init__(
         self,
-        *children: Any,
+        *children: Renderable,
         class_: str | None = None,
         id: str | None = None,
         style: str | None = None,
@@ -2086,7 +2086,7 @@ class Samp(Tag):
 
     def __init__(
         self,
-        *children: Any,
+        *children: Renderable,
         class_: str | None = None,
         id: str | None = None,
         style: str | None = None,
@@ -2100,7 +2100,7 @@ class Search(Tag):
 
     def __init__(
         self,
-        *children: Any,
+        *children: Renderable,
         class_: str | None = None,
         id: str | None = None,
         style: str | None = None,
@@ -2114,7 +2114,7 @@ class Section(Tag):
 
     def __init__(
         self,
-        *children: Any,
+        *children: Renderable,
         class_: str | None = None,
         id: str | None = None,
         style: str | None = None,
@@ -2128,7 +2128,7 @@ class Select(Tag):
 
     def __init__(
         self,
-        *children: Any,
+        *children: Renderable,
         autocomplete: str | None = None,
         autofocus: str | None = None,
         disabled: str | None = None,
@@ -2150,7 +2150,7 @@ class Small(Tag):
 
     def __init__(
         self,
-        *children: Any,
+        *children: Renderable,
         class_: str | None = None,
         id: str | None = None,
         style: str | None = None,
@@ -2164,7 +2164,7 @@ class Source(Tag):
 
     def __init__(
         self,
-        *children: Any,
+        *children: Renderable,
         src: str | None = None,
         type: str | None = None,
         sizes: str | None = None,
@@ -2185,7 +2185,7 @@ class Span(Tag):
 
     def __init__(
         self,
-        *children: Any,
+        *children: Renderable,
         class_: str | None = None,
         id: str | None = None,
         style: str | None = None,
@@ -2199,7 +2199,7 @@ class Strong(Tag):
 
     def __init__(
         self,
-        *children: Any,
+        *children: Renderable,
         class_: str | None = None,
         id: str | None = None,
         style: str | None = None,
@@ -2213,7 +2213,7 @@ class Sub(Tag):
 
     def __init__(
         self,
-        *children: Any,
+        *children: Renderable,
         class_: str | None = None,
         id: str | None = None,
         style: str | None = None,
@@ -2227,7 +2227,7 @@ class Summary(Tag):
 
     def __init__(
         self,
-        *children: Any,
+        *children: Renderable,
         class_: str | None = None,
         id: str | None = None,
         style: str | None = None,
@@ -2241,7 +2241,7 @@ class Sup(Tag):
 
     def __init__(
         self,
-        *children: Any,
+        *children: Renderable,
         class_: str | None = None,
         id: str | None = None,
         style: str | None = None,
@@ -2255,7 +2255,7 @@ class Table(Tag):
 
     def __init__(
         self,
-        *children: Any,
+        *children: Renderable,
         class_: str | None = None,
         id: str | None = None,
         style: str | None = None,
@@ -2269,7 +2269,7 @@ class Tbody(Tag):
 
     def __init__(
         self,
-        *children: Any,
+        *children: Renderable,
         class_: str | None = None,
         id: str | None = None,
         style: str | None = None,
@@ -2283,7 +2283,7 @@ class Td(Tag):
 
     def __init__(
         self,
-        *children: Any,
+        *children: Renderable,
         colspan: str | None = None,
         rowspan: str | None = None,
         headers: str | None = None,
@@ -2300,7 +2300,7 @@ class Template(Tag):
 
     def __init__(
         self,
-        *children: Any,
+        *children: Renderable,
         shadowrootmode: str | None = None,
         shadowrootdelegatesfocus: str | None = None,
         shadowrootclonable: str | None = None,
@@ -2317,7 +2317,7 @@ class Textarea(Tag):
 
     def __init__(
         self,
-        *children: Any,
+        *children: Renderable,
         autocapitalize: str | None = None,
         autocomplete: str | None = None,
         autocorrect: str | None = None,
@@ -2348,7 +2348,7 @@ class Tfoot(Tag):
 
     def __init__(
         self,
-        *children: Any,
+        *children: Renderable,
         class_: str | None = None,
         id: str | None = None,
         style: str | None = None,
@@ -2362,7 +2362,7 @@ class Th(Tag):
 
     def __init__(
         self,
-        *children: Any,
+        *children: Renderable,
         abbr: str | None = None,
         colspan: str | None = None,
         headers: str | None = None,
@@ -2381,7 +2381,7 @@ class Thead(Tag):
 
     def __init__(
         self,
-        *children: Any,
+        *children: Renderable,
         class_: str | None = None,
         id: str | None = None,
         style: str | None = None,
@@ -2395,7 +2395,7 @@ class Time(Tag):
 
     def __init__(
         self,
-        *children: Any,
+        *children: Renderable,
         datetime: str | None = None,
         class_: str | None = None,
         id: str | None = None,
@@ -2410,7 +2410,7 @@ class Title(Tag):
 
     def __init__(
         self,
-        *children: Any,
+        *children: Renderable,
         class_: str | None = None,
         id: str | None = None,
         style: str | None = None,
@@ -2424,7 +2424,7 @@ class Tr(Tag):
 
     def __init__(
         self,
-        *children: Any,
+        *children: Renderable,
         class_: str | None = None,
         id: str | None = None,
         style: str | None = None,
@@ -2438,7 +2438,7 @@ class Track(Tag):
 
     def __init__(
         self,
-        *children: Any,
+        *children: Renderable,
         default: str | None = None,
         kind: str | None = None,
         label: str | None = None,
@@ -2458,7 +2458,7 @@ class U(Tag):
 
     def __init__(
         self,
-        *children: Any,
+        *children: Renderable,
         compact: str | None = None,
         type: str | None = None,
         class_: str | None = None,
@@ -2474,7 +2474,7 @@ class Ul(Tag):
 
     def __init__(
         self,
-        *children: Any,
+        *children: Renderable,
         class_: str | None = None,
         id: str | None = None,
         style: str | None = None,
@@ -2488,7 +2488,7 @@ class Var(Tag):
 
     def __init__(
         self,
-        *children: Any,
+        *children: Renderable,
         class_: str | None = None,
         id: str | None = None,
         style: str | None = None,
@@ -2502,7 +2502,7 @@ class Video(Tag):
 
     def __init__(
         self,
-        *children: Any,
+        *children: Renderable,
         src: str | None = None,
         autoplay: str | None = None,
         controls: str | None = None,
@@ -2530,7 +2530,7 @@ class Wbr(Tag):
 
     def __init__(
         self,
-        *children: Any,
+        *children: Renderable,
         class_: str | None = None,
         id: str | None = None,
         style: str | None = None,

--- a/src/air/tags/models/stock.py
+++ b/src/air/tags/models/stock.py
@@ -2,10 +2,8 @@
 
 Script and Style tags can be found in the [air.tags.models.special](/reference/air.tags.models.special) page."""
 
-from typing import Any
-
 from ..utils import locals_cleanup
-from .base import Tag, Renderable
+from .base import Renderable, Tag
 
 
 class A(Tag):

--- a/src/air/tags/models/svg.py
+++ b/src/air/tags/models/svg.py
@@ -2,10 +2,8 @@
 is supported.
 """
 
-from typing import Any
-
 from ..utils import locals_cleanup
-from .base import Tag, Renderable
+from .base import Renderable, Tag
 
 
 class CaseTag(Tag):

--- a/src/air/tags/models/svg.py
+++ b/src/air/tags/models/svg.py
@@ -5,7 +5,7 @@ is supported.
 from typing import Any
 
 from ..utils import locals_cleanup
-from .base import Tag
+from .base import Tag, Renderable
 
 
 class CaseTag(Tag):
@@ -37,7 +37,7 @@ class A(CaseTag):
 
     def __init__(
         self,
-        *children: Any,
+        *children: Renderable,
         href: str | None = None,
         target: str | None = None,
         download: str | None = None,
@@ -79,7 +79,7 @@ class Animate(CaseTag):
 
     def __init__(
         self,
-        *children: Any,
+        *children: Renderable,
         attributeName: str | None = None,
         attributeType: str | None = None,
         values: str | None = None,
@@ -119,7 +119,7 @@ class AnimateMotion(CaseTag):
 
     def __init__(
         self,
-        *children: Any,
+        *children: Renderable,
         path: str | None = None,
         keyPoints: str | None = None,
         rotate: str | float | None = None,
@@ -154,7 +154,7 @@ class AnimateTransform(CaseTag):
 
     def __init__(
         self,
-        *children: Any,
+        *children: Renderable,
         type: str | None = None,
         by: str | None = None,
         from_: str | None = None,
@@ -187,7 +187,7 @@ class Circle(CaseTag):
 
     def __init__(
         self,
-        *children: Any,
+        *children: Renderable,
         cx: str | float | None = None,
         cy: str | float | None = None,
         r: str | float | None = None,
@@ -214,7 +214,7 @@ class ClipPath(CaseTag):
 
     def __init__(
         self,
-        *children: Any,
+        *children: Renderable,
         clipPathUnits: str | None = None,
         class_: str | None = None,
         id: str | None = None,
@@ -237,7 +237,7 @@ class Defs(CaseTag):
 
     def __init__(
         self,
-        *children: Any,
+        *children: Renderable,
         class_: str | None = None,
         id: str | None = None,
         style: str | None = None,
@@ -259,7 +259,7 @@ class Desc(CaseTag):
 
     def __init__(
         self,
-        *children: Any,
+        *children: Renderable,
         class_: str | None = None,
         id: str | None = None,
         style: str | None = None,
@@ -286,7 +286,7 @@ class Ellipse(CaseTag):
 
     def __init__(
         self,
-        *children: Any,
+        *children: Renderable,
         cx: str | float | None = None,
         cy: str | float | None = None,
         rx: str | float | None = None,
@@ -317,7 +317,7 @@ class FeBlend(CaseTag):
 
     def __init__(
         self,
-        *children: Any,
+        *children: Renderable,
         in_: str | None = None,
         in2: str | None = None,
         mode: str | None = None,
@@ -347,7 +347,7 @@ class FeColorMatrix(CaseTag):
 
     def __init__(
         self,
-        *children: Any,
+        *children: Renderable,
         in_: str | None = None,
         type: str | None = None,
         values: str | None = None,
@@ -375,7 +375,7 @@ class FeComponentTransfer(CaseTag):
 
     def __init__(
         self,
-        *children: Any,
+        *children: Renderable,
         in_: str | None = None,
         result: str | None = None,
         class_: str | None = None,
@@ -407,7 +407,7 @@ class FeComposite(CaseTag):
 
     def __init__(
         self,
-        *children: Any,
+        *children: Renderable,
         in_: str | None = None,
         in2: str | None = None,
         operator: str | None = None,
@@ -447,7 +447,7 @@ class FeConvolveMatrix(CaseTag):
 
     def __init__(
         self,
-        *children: Any,
+        *children: Renderable,
         in_: str | None = None,
         order: str | None = None,
         kernelMatrix: str | None = None,
@@ -484,7 +484,7 @@ class FeDiffuseLighting(CaseTag):
 
     def __init__(
         self,
-        *children: Any,
+        *children: Renderable,
         in_: str | None = None,
         surfaceScale: float | None = None,
         diffuseConstant: float | None = None,
@@ -517,7 +517,7 @@ class FeDisplacementMap(CaseTag):
 
     def __init__(
         self,
-        *children: Any,
+        *children: Renderable,
         in_: str | None = None,
         in2: str | None = None,
         scale: float | None = None,
@@ -547,7 +547,7 @@ class FeDistantLight(CaseTag):
 
     def __init__(
         self,
-        *children: Any,
+        *children: Renderable,
         azimuth: str | float | None = None,
         elevation: str | float | None = None,
         class_: str | None = None,
@@ -576,7 +576,7 @@ class FeDropShadow(CaseTag):
 
     def __init__(
         self,
-        *children: Any,
+        *children: Renderable,
         dx: str | float | None = None,
         dy: str | float | None = None,
         stdDeviation: str | float | None = None,
@@ -606,7 +606,7 @@ class FeFlood(CaseTag):
 
     def __init__(
         self,
-        *children: Any,
+        *children: Renderable,
         flood_color: str | None = None,
         flood_opacity: str | float | None = None,
         result: str | None = None,
@@ -638,7 +638,7 @@ class FeFuncA(CaseTag):
 
     def __init__(
         self,
-        *children: Any,
+        *children: Renderable,
         type: str | None = None,
         tableValues: str | None = None,
         slope: float | None = None,
@@ -674,7 +674,7 @@ class FeFuncB(CaseTag):
 
     def __init__(
         self,
-        *children: Any,
+        *children: Renderable,
         type: str | None = None,
         tableValues: str | None = None,
         slope: float | None = None,
@@ -710,7 +710,7 @@ class FeFuncG(CaseTag):
 
     def __init__(
         self,
-        *children: Any,
+        *children: Renderable,
         type: str | None = None,
         tableValues: str | None = None,
         slope: float | None = None,
@@ -746,7 +746,7 @@ class FeFuncR(CaseTag):
 
     def __init__(
         self,
-        *children: Any,
+        *children: Renderable,
         type: str | None = None,
         tableValues: str | None = None,
         slope: float | None = None,
@@ -779,7 +779,7 @@ class FeGaussianBlur(CaseTag):
 
     def __init__(
         self,
-        *children: Any,
+        *children: Renderable,
         in_: str | None = None,
         stdDeviation: str | float | None = None,
         edgeMode: str | None = None,
@@ -809,7 +809,7 @@ class FeImage(CaseTag):
 
     def __init__(
         self,
-        *children: Any,
+        *children: Renderable,
         href: str | None = None,
         preserveAspectRatio: str | None = None,
         crossorigin: str | None = None,
@@ -836,7 +836,7 @@ class FeMerge(CaseTag):
 
     def __init__(
         self,
-        *children: Any,
+        *children: Renderable,
         result: str | None = None,
         class_: str | None = None,
         id: str | None = None,
@@ -860,7 +860,7 @@ class FeMergeNode(CaseTag):
 
     def __init__(
         self,
-        *children: Any,
+        *children: Renderable,
         in_: str | None = None,
         class_: str | None = None,
         id: str | None = None,
@@ -887,7 +887,7 @@ class FeMorphology(CaseTag):
 
     def __init__(
         self,
-        *children: Any,
+        *children: Renderable,
         in_: str | None = None,
         operator: str | None = None,
         radius: str | float | None = None,
@@ -917,7 +917,7 @@ class FeOffset(CaseTag):
 
     def __init__(
         self,
-        *children: Any,
+        *children: Renderable,
         in_: str | None = None,
         dx: str | float | None = None,
         dy: str | float | None = None,
@@ -946,7 +946,7 @@ class FePointLight(CaseTag):
 
     def __init__(
         self,
-        *children: Any,
+        *children: Renderable,
         x: str | float | None = None,
         y: str | float | None = None,
         z: str | float | None = None,
@@ -977,7 +977,7 @@ class FeSpecularLighting(CaseTag):
 
     def __init__(
         self,
-        *children: Any,
+        *children: Renderable,
         in_: str | None = None,
         surfaceScale: float | None = None,
         specularConstant: float | None = None,
@@ -1013,7 +1013,7 @@ class FeSpotLight(CaseTag):
 
     def __init__(
         self,
-        *children: Any,
+        *children: Renderable,
         x: str | float | None = None,
         y: str | float | None = None,
         z: str | float | None = None,
@@ -1045,7 +1045,7 @@ class FeTile(CaseTag):
 
     def __init__(
         self,
-        *children: Any,
+        *children: Renderable,
         in_: str | None = None,
         result: str | None = None,
         class_: str | None = None,
@@ -1075,7 +1075,7 @@ class FeTurbulence(CaseTag):
 
     def __init__(
         self,
-        *children: Any,
+        *children: Renderable,
         baseFrequency: str | float | None = None,
         numOctaves: int | None = None,
         seed: float | None = None,
@@ -1109,7 +1109,7 @@ class Filter(CaseTag):
 
     def __init__(
         self,
-        *children: Any,
+        *children: Renderable,
         x: str | float | None = None,
         y: str | float | None = None,
         width: str | float | None = None,
@@ -1141,7 +1141,7 @@ class ForeignObject(CaseTag):
 
     def __init__(
         self,
-        *children: Any,
+        *children: Renderable,
         x: str | float | None = None,
         y: str | float | None = None,
         width: str | float | None = None,
@@ -1167,7 +1167,7 @@ class G(CaseTag):
 
     def __init__(
         self,
-        *children: Any,
+        *children: Renderable,
         class_: str | None = None,
         id: str | None = None,
         style: str | None = None,
@@ -1198,7 +1198,7 @@ class Image(CaseTag):
 
     def __init__(
         self,
-        *children: Any,
+        *children: Renderable,
         x: str | float | None = None,
         y: str | float | None = None,
         width: str | float | None = None,
@@ -1234,7 +1234,7 @@ class Line(CaseTag):
 
     def __init__(
         self,
-        *children: Any,
+        *children: Renderable,
         x1: str | float | None = None,
         y1: str | float | None = None,
         x2: str | float | None = None,
@@ -1269,7 +1269,7 @@ class LinearGradient(CaseTag):
 
     def __init__(
         self,
-        *children: Any,
+        *children: Renderable,
         x1: str | float | None = None,
         y1: str | float | None = None,
         x2: str | float | None = None,
@@ -1307,7 +1307,7 @@ class Marker(CaseTag):
 
     def __init__(
         self,
-        *children: Any,
+        *children: Renderable,
         markerWidth: str | float | None = None,
         markerHeight: str | float | None = None,
         markerUnits: str | None = None,
@@ -1344,7 +1344,7 @@ class Mask(CaseTag):
 
     def __init__(
         self,
-        *children: Any,
+        *children: Renderable,
         x: str | float | None = None,
         y: str | float | None = None,
         width: str | float | None = None,
@@ -1373,7 +1373,7 @@ class Metadata(CaseTag):
 
     def __init__(
         self,
-        *children: Any,
+        *children: Renderable,
         class_: str | None = None,
         id: str | None = None,
         style: str | None = None,
@@ -1396,7 +1396,7 @@ class Mpath(CaseTag):
 
     def __init__(
         self,
-        *children: Any,
+        *children: Renderable,
         href: str | None = None,
         class_: str | None = None,
         id: str | None = None,
@@ -1421,7 +1421,7 @@ class Path(CaseTag):
 
     def __init__(
         self,
-        *children: Any,
+        *children: Renderable,
         d: str | None = None,
         pathLength: float | None = None,
         class_: str | None = None,
@@ -1455,7 +1455,7 @@ class Pattern(CaseTag):
 
     def __init__(
         self,
-        *children: Any,
+        *children: Renderable,
         x: str | float | None = None,
         y: str | float | None = None,
         width: str | float | None = None,
@@ -1489,7 +1489,7 @@ class Polygon(CaseTag):
 
     def __init__(
         self,
-        *children: Any,
+        *children: Renderable,
         points: str | None = None,
         pathLength: float | None = None,
         class_: str | None = None,
@@ -1515,7 +1515,7 @@ class Polyline(CaseTag):
 
     def __init__(
         self,
-        *children: Any,
+        *children: Renderable,
         points: str | None = None,
         pathLength: float | None = None,
         class_: str | None = None,
@@ -1549,7 +1549,7 @@ class RadialGradient(CaseTag):
 
     def __init__(
         self,
-        *children: Any,
+        *children: Renderable,
         cx: str | float | None = None,
         cy: str | float | None = None,
         r: str | float | None = None,
@@ -1588,7 +1588,7 @@ class Rect(CaseTag):
 
     def __init__(
         self,
-        *children: Any,
+        *children: Renderable,
         x: str | float | None = None,
         y: str | float | None = None,
         width: str | float | None = None,
@@ -1621,7 +1621,7 @@ class Script(CaseTag):
 
     def __init__(
         self,
-        *children: Any,
+        *children: Renderable,
         type: str | None = None,
         href: str | None = None,
         crossorigin: str | None = None,
@@ -1651,7 +1651,7 @@ class Set(CaseTag):
 
     def __init__(
         self,
-        *children: Any,
+        *children: Renderable,
         to: str | None = None,
         attributeName: str | None = None,
         begin: str | None = None,
@@ -1680,7 +1680,7 @@ class Stop(CaseTag):
 
     def __init__(
         self,
-        *children: Any,
+        *children: Renderable,
         offset: str | float | None = None,
         stop_color: str | None = None,
         stop_opacity: str | float | None = None,
@@ -1707,7 +1707,7 @@ class Style(CaseTag):
 
     def __init__(
         self,
-        *children: Any,
+        *children: Renderable,
         type: str | None = None,
         media: str | None = None,
         class_: str | None = None,
@@ -1737,7 +1737,7 @@ class Svg(CaseTag):
 
     def __init__(
         self,
-        *children: Any,
+        *children: Renderable,
         width: str | float | None = None,
         height: str | float | None = None,
         x: str | float | None = None,
@@ -1765,7 +1765,7 @@ class Switch(CaseTag):
 
     def __init__(
         self,
-        *children: Any,
+        *children: Renderable,
         class_: str | None = None,
         id: str | None = None,
         style: str | None = None,
@@ -1795,7 +1795,7 @@ class Symbol(CaseTag):
 
     def __init__(
         self,
-        *children: Any,
+        *children: Renderable,
         width: str | float | None = None,
         height: str | float | None = None,
         x: str | float | None = None,
@@ -1832,7 +1832,7 @@ class Text(CaseTag):
 
     def __init__(
         self,
-        *children: Any,
+        *children: Renderable,
         x: str | float | None = None,
         y: str | float | None = None,
         dx: str | float | None = None,
@@ -1869,7 +1869,7 @@ class TextPath(CaseTag):
 
     def __init__(
         self,
-        *children: Any,
+        *children: Renderable,
         href: str | None = None,
         lengthAdjust: str | None = None,
         method: str | None = None,
@@ -1899,7 +1899,7 @@ class Title(CaseTag):
 
     def __init__(
         self,
-        *children: Any,
+        *children: Renderable,
         class_: str | None = None,
         id: str | None = None,
         style: str | None = None,
@@ -1928,7 +1928,7 @@ class Tspan(CaseTag):
 
     def __init__(
         self,
-        *children: Any,
+        *children: Renderable,
         x: str | float | None = None,
         y: str | float | None = None,
         dx: str | float | None = None,
@@ -1962,7 +1962,7 @@ class Use(CaseTag):
 
     def __init__(
         self,
-        *children: Any,
+        *children: Renderable,
         href: str | None = None,
         x: str | float | None = None,
         y: str | float | None = None,
@@ -1991,7 +1991,7 @@ class View(CaseTag):
 
     def __init__(
         self,
-        *children: Any,
+        *children: Renderable,
         viewBox: str | None = None,
         preserveAspectRatio: str | None = None,
         class_: str | None = None,

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 3
+revision = 2
 requires-python = ">=3.10, <3.14"
 conflicts = [[
     { package = "air", extra = "standard" },
@@ -141,10 +141,10 @@ name = "anyio"
 version = "4.10.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "exceptiongroup", marker = "python_full_version < '3.11' or (extra == 'extra-3-air-standard' and extra == 'group-3-air-dev') or (extra == 'extra-3-air-standard' and extra == 'group-3-air-devtools')" },
+    { name = "exceptiongroup", marker = "python_full_version < '3.11'" },
     { name = "idna" },
     { name = "sniffio" },
-    { name = "typing-extensions", marker = "python_full_version < '3.13' or (extra == 'extra-3-air-standard' and extra == 'group-3-air-dev') or (extra == 'extra-3-air-standard' and extra == 'group-3-air-devtools')" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/f1/b4/636b3b65173d3ce9a38ef5f0522789614e590dab6a8d505340a4efe4c567/anyio-4.10.0.tar.gz", hash = "sha256:3f3fae35c96039744587aa5b8371e7e8e603c0702999535961dd336026973ba6", size = 213252, upload-time = "2025-08-04T08:54:26.451Z" }
 wheels = [
@@ -326,7 +326,7 @@ wheels = [
 
 [package.optional-dependencies]
 toml = [
-    { name = "tomli", marker = "python_full_version <= '3.11' or (extra == 'extra-3-air-standard' and extra == 'group-3-air-dev') or (extra == 'extra-3-air-standard' and extra == 'group-3-air-devtools')" },
+    { name = "tomli", marker = "python_full_version <= '3.11'" },
 ]
 
 [[package]]
@@ -380,7 +380,7 @@ name = "exceptiongroup"
 version = "1.3.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions", marker = "python_full_version < '3.13' or (extra == 'extra-3-air-standard' and extra == 'group-3-air-dev') or (extra == 'extra-3-air-standard' and extra == 'group-3-air-devtools')" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/0b/9f/a65090624ecf468cdca03533906e7c69ed7588582240cfe7cc9e770b50eb/exceptiongroup-1.3.0.tar.gz", hash = "sha256:b241f5885f560bc56a59ee63ca4c6a8bfa46ae4ad651af316d4e81817bb9fd88", size = 29749, upload-time = "2025-05-10T17:42:51.123Z" }
 wheels = [
@@ -392,8 +392,8 @@ name = "fancycompleter"
 version = "0.11.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "pyreadline3", marker = "(python_full_version < '3.13' and sys_platform == 'win32') or (python_full_version >= '3.13' and extra == 'extra-3-air-standard' and extra == 'group-3-air-dev') or (python_full_version >= '3.13' and extra == 'extra-3-air-standard' and extra == 'group-3-air-devtools') or (sys_platform != 'win32' and extra == 'extra-3-air-standard' and extra == 'group-3-air-dev') or (sys_platform != 'win32' and extra == 'extra-3-air-standard' and extra == 'group-3-air-devtools')" },
-    { name = "pyrepl", marker = "python_full_version < '3.13' or (extra == 'extra-3-air-standard' and extra == 'group-3-air-dev') or (extra == 'extra-3-air-standard' and extra == 'group-3-air-devtools')" },
+    { name = "pyreadline3", marker = "python_full_version < '3.13' and sys_platform == 'win32'" },
+    { name = "pyrepl", marker = "python_full_version < '3.13'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/4e/4c/d11187dee93eff89d082afda79b63c79320ae1347e49485a38f05ad359d0/fancycompleter-0.11.1.tar.gz", hash = "sha256:5b4ad65d76b32b1259251516d0f1cb2d82832b1ff8506697a707284780757f69", size = 341776, upload-time = "2025-05-26T12:59:11.045Z" }
 wheels = [
@@ -888,13 +888,13 @@ name = "pytest"
 version = "8.4.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "colorama", marker = "sys_platform == 'win32' or (extra == 'extra-3-air-standard' and extra == 'group-3-air-dev') or (extra == 'extra-3-air-standard' and extra == 'group-3-air-devtools')" },
-    { name = "exceptiongroup", marker = "python_full_version < '3.11' or (extra == 'extra-3-air-standard' and extra == 'group-3-air-dev') or (extra == 'extra-3-air-standard' and extra == 'group-3-air-devtools')" },
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "exceptiongroup", marker = "python_full_version < '3.11'" },
     { name = "iniconfig" },
     { name = "packaging" },
     { name = "pluggy" },
     { name = "pygments" },
-    { name = "tomli", marker = "python_full_version < '3.11' or (extra == 'extra-3-air-standard' and extra == 'group-3-air-dev') or (extra == 'extra-3-air-standard' and extra == 'group-3-air-devtools')" },
+    { name = "tomli", marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/a3/5c/00a0e072241553e1a7496d638deababa67c5058571567b92a7eaa258397c/pytest-8.4.2.tar.gz", hash = "sha256:86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01", size = 1519618, upload-time = "2025-09-04T14:34:22.711Z" }
 wheels = [
@@ -906,7 +906,7 @@ name = "pytest-asyncio"
 version = "1.1.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "backports-asyncio-runner", marker = "python_full_version < '3.11' or (extra == 'extra-3-air-standard' and extra == 'group-3-air-dev') or (extra == 'extra-3-air-standard' and extra == 'group-3-air-devtools')" },
+    { name = "backports-asyncio-runner", marker = "python_full_version < '3.11'" },
     { name = "pytest" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/4e/51/f8794af39eeb870e87a8c8068642fc07bce0c854d6865d7dd0f2a9d338c2/pytest_asyncio-1.1.0.tar.gz", hash = "sha256:796aa822981e01b68c12e4827b8697108f7205020f24b5793b3c41555dab68ea", size = 46652, upload-time = "2025-07-16T04:29:26.393Z" }
@@ -1290,7 +1290,7 @@ version = "0.47.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
-    { name = "typing-extensions", marker = "python_full_version < '3.13' or (extra == 'extra-3-air-standard' and extra == 'group-3-air-dev') or (extra == 'extra-3-air-standard' and extra == 'group-3-air-devtools')" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/15/b9/cc3017f9a9c9b6e27c5106cc10cc7904653c3eec0729793aec10479dd669/starlette-0.47.3.tar.gz", hash = "sha256:6bc94f839cc176c4858894f1f8908f0ab79dfec1a6b8402f6da9be26ebea52e9", size = 2584144, upload-time = "2025-08-24T13:36:42.122Z" }
 wheels = [


### PR DESCRIPTION
This pull request introduces a new `Renderable` type to clarify and restrict what types of content can be rendered as children in HTML tag components. It replaces the generic `Any` type with `Renderable` in the constructors of the base `Tag` class and all standard HTML tag classes, ensuring type safety and preventing unintended or invalid HTML output. Additionally, it updates layout functions to use this new type.

Type safety and content rendering improvements:

* Introduced the `Renderable` type in `src/air/tags/models/base.py`, defined as `Union[str, "Tag", SafeStr, int, float]`, to restrict renderable content and avoid undesirable HTML output from types like `None`, `bool`, `complex`, and `bytes`.
* Updated the base `Tag` class and all standard HTML tag classes in `src/air/tags/models/stock.py` to use `*children: Renderable` instead of `Any`, ensuring only valid content types are accepted as children. [[1]](diffhunk://#diff-764bff5d67767a3f65650d15b3eb12beb3860016035f3e45c0a11d6cee5967e3L33-R33) [[2]](diffhunk://#diff-764bff5d67767a3f65650d15b3eb12beb3860016035f3e45c0a11d6cee5967e3L64-R64) [[3]](diffhunk://#diff-764bff5d67767a3f65650d15b3eb12beb3860016035f3e45c0a11d6cee5967e3L86-R86) [[4]](diffhunk://#diff-764bff5d67767a3f65650d15b3eb12beb3860016035f3e45c0a11d6cee5967e3L117-R117) [[5]](diffhunk://#diff-764bff5d67767a3f65650d15b3eb12beb3860016035f3e45c0a11d6cee5967e3L149-R149) [[6]](diffhunk://#diff-764bff5d67767a3f65650d15b3eb12beb3860016035f3e45c0a11d6cee5967e3L171-R171) [[7]](diffhunk://#diff-764bff5d67767a3f65650d15b3eb12beb3860016035f3e45c0a11d6cee5967e3L199-R199) [[8]](diffhunk://#diff-764bff5d67767a3f65650d15b3eb12beb3860016035f3e45c0a11d6cee5967e3L227-R227) [[9]](diffhunk://#diff-764bff5d67767a3f65650d15b3eb12beb3860016035f3e45c0a11d6cee5967e3L249-R249) [[10]](diffhunk://#diff-764bff5d67767a3f65650d15b3eb12beb3860016035f3e45c0a11d6cee5967e3L274-R274) [[11]](diffhunk://#diff-764bff5d67767a3f65650d15b3eb12beb3860016035f3e45c0a11d6cee5967e3L297-R297) [[12]](diffhunk://#diff-764bff5d67767a3f65650d15b3eb12beb3860016035f3e45c0a11d6cee5967e3L321-R321) [[13]](diffhunk://#diff-764bff5d67767a3f65650d15b3eb12beb3860016035f3e45c0a11d6cee5967e3L341-R341) [[14]](diffhunk://#diff-764bff5d67767a3f65650d15b3eb12beb3860016035f3e45c0a11d6cee5967e3L360-R360) [[15]](diffhunk://#diff-764bff5d67767a3f65650d15b3eb12beb3860016035f3e45c0a11d6cee5967e3L396-R396) [[16]](diffhunk://#diff-764bff5d67767a3f65650d15b3eb12beb3860016035f3e45c0a11d6cee5967e3L433-R433) [[17]](diffhunk://#diff-764bff5d67767a3f65650d15b3eb12beb3860016035f3e45c0a11d6cee5967e3L457-R457) [[18]](diffhunk://#diff-764bff5d67767a3f65650d15b3eb12beb3860016035f3e45c0a11d6cee5967e3L479-R479) [[19]](diffhunk://#diff-764bff5d67767a3f65650d15b3eb12beb3860016035f3e45c0a11d6cee5967e3L501-R501) [[20]](diffhunk://#diff-764bff5d67767a3f65650d15b3eb12beb3860016035f3e45c0a11d6cee5967e3L524-R524) [[21]](diffhunk://#diff-764bff5d67767a3f65650d15b3eb12beb3860016035f3e45c0a11d6cee5967e3L549-R549) [[22]](diffhunk://#diff-764bff5d67767a3f65650d15b3eb12beb3860016035f3e45c0a11d6cee5967e3L573-R573) [[23]](diffhunk://#diff-764bff5d67767a3f65650d15b3eb12beb3860016035f3e45c0a11d6cee5967e3L596-R596) [[24]](diffhunk://#diff-764bff5d67767a3f65650d15b3eb12beb3860016035f3e45c0a11d6cee5967e3L620-R620) [[25]](diffhunk://#diff-764bff5d67767a3f65650d15b3eb12beb3860016035f3e45c0a11d6cee5967e3L644-R644) [[26]](diffhunk://#diff-764bff5d67767a3f65650d15b3eb12beb3860016035f3e45c0a11d6cee5967e3L667-R667) [[27]](diffhunk://#diff-764bff5d67767a3f65650d15b3eb12beb3860016035f3e45c0a11d6cee5967e3L690-R690) [[28]](diffhunk://#diff-764bff5d67767a3f65650d15b3eb12beb3860016035f3e45c0a11d6cee5967e3L713-R713) [[29]](diffhunk://#diff-764bff5d67767a3f65650d15b3eb12beb3860016035f3e45c0a11d6cee5967e3L736-R736) [[30]](diffhunk://#diff-764bff5d67767a3f65650d15b3eb12beb3860016035f3e45c0a11d6cee5967e3L758-R758) [[31]](diffhunk://#diff-764bff5d67767a3f65650d15b3eb12beb3860016035f3e45c0a11d6cee5967e3L780-R780) [[32]](diffhunk://#diff-764bff5d67767a3f65650d15b3eb12beb3860016035f3e45c0a11d6cee5967e3L802-R802) [[33]](diffhunk://#diff-764bff5d67767a3f65650d15b3eb12beb3860016035f3e45c0a11d6cee5967e3L828-R828) [[34]](diffhunk://#diff-764bff5d67767a3f65650d15b3eb12beb3860016035f3e45c0a11d6cee5967e3L858-R858) [[35]](diffhunk://#diff-764bff5d67767a3f65650d15b3eb12beb3860016035f3e45c0a11d6cee5967e3L883-R883)
* Updated the `Tag` class constructor to use the new `Renderable` type for children and explicitly typed internal attributes for children and attributes.

Layout function updates:

* Updated the `mvpcss` and `picocss` layout functions in `src/air/layouts.py` to accept `*children: Renderable` for consistency and improved type safety. [[1]](diffhunk://#diff-5db2f70157fa9e32d1bb9019f84a1ed8b3a1c1a00803eb13ab0bc9b2fe04978cL40-R41) [[2]](diffhunk://#diff-5db2f70157fa9e32d1bb9019f84a1ed8b3a1c1a00803eb13ab0bc9b2fe04978cL109-R110)
* Imported the `Renderable` type where needed in `src/air/layouts.py` and `src/air/tags/models/stock.py`. [[1]](diffhunk://#diff-5db2f70157fa9e32d1bb9019f84a1ed8b3a1c1a00803eb13ab0bc9b2fe04978cR18) [[2]](diffhunk://#diff-764bff5d67767a3f65650d15b3eb12beb3860016035f3e45c0a11d6cee5967e3L8-R8)