### PR TITLE
resolve type-check errors pyrefly in docs by adding path

### DIFF
--- a/justfile
+++ b/justfile
@@ -123,7 +123,7 @@ lint OUTPUT_FORMAT="full":
 [group('qa')]
 type-check:
     uv run -q -- ty check .
-    # just run-with-relative-paths uv run -q -- pyrefly check .
+    just run-with-relative-paths uv run -q -- pyrefly check .
 
 # Type check the project with Ty and pyrefly - Print diagnostics concisely, one per line
 [group('qa')]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -449,15 +449,14 @@ possibly-unresolved-reference = "warn"
 
 # region ----> pyrefly <----
 [tool.pyrefly]
-project-includes = ["src", "tests"] # keep discovery stable
+project-includes = ["src", "tests", "docs"] # keep discovery stable
 project-excludes = [
     "**/__pycache__",
     "**/*venv/**/*",
-    "docs"
 ]
 use-ignore-files = true
 #### configuring what to type check and where to import from
-search-path = ["src"]
+search-path = ["src", "docs"]
 python-version = "3.13"
 # Keep resolution stable (meaning: predictable, same every run)
 disable-search-path-heuristics = true


### PR DESCRIPTION
This PR addresses the issue where Pyrefly reported errors due to incorrect import paths for the docs folder.

Changes made:

Fixed the import path so `Pyrefly` can properly analyze the docs folder.

Updated justfile to run both `ty` and `pyrefly` for type checking.

This ensures type checks run consistently and prevent similar errors from being missed in the future.