### PR TITLE
Add latest-changes GitHub Action workflow (Issue #163)

### DIFF
--- a/.github/workflows/latest-changes.yml
+++ b/.github/workflows/latest-changes.yml
@@ -1,0 +1,22 @@
+name: Latest Changes
+
+on:
+  pull_request_target:
+    branches:
+      - main
+    types:
+      - closed
+
+jobs:
+  latest-changes:
+    runs-on: ubuntu-latest
+    if: github.event.pull_request.merged == true
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+      - uses: tiangolo/latest-changes@0.4.0
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          latest_changes_file: CHANGELOG.md
+          latest_changes_header: "## Latest Changes"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+## Latest Changes
+
 # 0.29.0 - 2025-09-12
 
 ## What's Changed


### PR DESCRIPTION
  - Add .github/workflows/latest-changes.yml to automatically update CHANGELOG.md
  - Add 'Latest Changes' section to CHANGELOG.md for new PR entries