### PR TITLE
Updated the example usage command to `just run-py-module examples.tags_render`.

### DIFF
--- a/examples/tags_render.py
+++ b/examples/tags_render.py
@@ -7,8 +7,7 @@ structure. It then utilizes a rendering function to display the generated
 HTML in a nicely formatted panel with syntax highlighting and stylized
 borders in the terminal.
 Run:
-    `uv sync --all-extras --no-extra standard`
-    `just run examples.tags_render`
+    `just run-py-module examples.tags_render`
 """
 
 from __future__ import annotations


### PR DESCRIPTION
- Updated the example usage command to `just run-py-module examples.tags_render`.

Fixes #436 