### PR TITLE
Add GitHub OAuth router Factory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -69,8 +69,6 @@ target/
 # macOS
 .DS_Store
 
-# Air static site generator - generated output
-public/
 
 # Docs page
 site
@@ -91,6 +89,7 @@ nbs
 .cursor/
 .vscode/
 .idea/
+examples/.env
 
 
 # START Ruler Generated Files

--- a/docs/api/ext/auth.md
+++ b/docs/api/ext/auth.md
@@ -5,4 +5,4 @@
     options:
       group_by_category: false
       members:
-        - GitHubOAuthRouter
+        - GitHubOAuthRouterFactory

--- a/docs/api/ext/auth.md
+++ b/docs/api/ext/auth.md
@@ -1,0 +1,8 @@
+# ext.auth
+
+
+::: air.ext.auth
+    options:
+      group_by_category: false
+      members:
+        - GitHubOAuthRouter

--- a/docs/api/ext/index.md
+++ b/docs/api/ext/index.md
@@ -2,4 +2,5 @@
 
 Functionality for Air that requires extra dependencies.
 
+- [Auth](auth) - Authentication tools for OAuth and eventually email and magic link.
 - [SQL](sql) - Utilities for connecting to relational databases like PostgreSQL, MySQL, and SQLite.

--- a/examples/github_oauth_demo.py
+++ b/examples/github_oauth_demo.py
@@ -1,0 +1,56 @@
+"""
+A demonstration of the basic auth capabilities of AIR.
+This little app demonstrates how to use AIR for authentication.
+Run:
+
+    uv sync --all-extras --no-extra standard
+    uv run --env-file .env fastapi dev github_oauth_demo.py
+"""
+
+from datetime import datetime
+from os import environ
+
+from rich import print
+
+import air
+
+database = {}
+
+
+async def github_process_callable(request: air.Request, token: dict, client: str = "") -> None:
+    access_token = token["access_token"]
+    print(access_token)
+    if access_token in database:
+        database[access_token]["updated_at"] = datetime.now()
+    else:
+        database[access_token] = token
+        database[access_token]["created_at"] = datetime.now()
+        database[access_token]["updated_at"] = datetime.now()
+        database[access_token]["access_token"] = access_token
+    request.session["github_access_token"] = access_token
+    print(database)
+
+
+github_oauth_router = air.ext.GitHubOAuthRouterFactory(
+    github_client_id=environ["GITHUB_CLIENT_ID"],
+    github_client_secret=environ["GITHUB_CLIENT_SECRET"],
+    github_process_callable=github_process_callable,
+    login_redirect_to="/",
+)
+
+
+app = air.Air()
+app.add_middleware(air.SessionMiddleware, secret_key="change-me")
+app.include_router(github_oauth_router)
+
+
+database = {}
+
+
+@app.page
+async def index(request: air.Request):
+    return air.layouts.mvpcss(
+        air.H1("GitHub OAuth Login Demo"),
+        air.P(air.A("Login to Github", href="/account/github/login")),
+        air.P(request.session.get("github_access_token", "Not authenticated yet")),
+    )

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -34,6 +34,7 @@ nav:
     - Exceptions: api/exceptions.md
     - Ext: 
       - Ext: api/ext/index.md
+      - Auth: api/ext/auth
       - SQL: api/ext/sql.md
     - Forms: api/forms.md
     - Layouts: api/layouts.md

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,6 +62,10 @@ sql = [
     "greenlet>=3.2.4", # Dependency for SQLAlchemy to run async
     "sqlmodel>=0.0.24", # Bridge between SQLAlchemy and Pydantic
 ]
+# Used for authentication
+auth = [
+    "authlib>=1.6.3", # OAuth clients
+]
 
 # Groups are for contributors; install with: uv sync --group NAME
 # Developer-only deps under [dependency-groups],
@@ -501,6 +505,7 @@ bad-unpacking = false
 index-error = false
 import-error = false
 bad-argument-count = false
+missing-attribute = false
 
 # endregion pyrefly
 

--- a/src/air/ext/__init__.py
+++ b/src/air/ext/__init__.py
@@ -1,3 +1,27 @@
+from collections.abc import Callable
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    GitHubOAuthRouterFactory: Callable
+
+try:
+    from .auth import GitHubOAuthRouterFactory as GitHubOAuthRouterFactory
+except ImportError:  # pragma: no cover
+    msg = "air.ext.auth requires installing the authlib package."
+
+    class NotImportable:
+        def __getattribute__(self, name):
+            raise RuntimeError(msg)
+
+        def __str__(self):
+            return msg
+
+        def __repr__(self):
+            return msg
+
+    auth = NotImportable()
+
+
 try:
     from .sql import (
         AsyncSession as AsyncSession,
@@ -8,7 +32,7 @@ try:
         get_async_session as get_async_session,
     )
 except ImportError:  # pragma: no cover
-    msg = "air.db.sql requires installing the sqlmodel and greenlet packages."
+    msg = "air.ext.sql requires installing the sqlmodel and greenlet packages."
 
     class NotImportable:
         def __getattribute__(self, name):

--- a/src/air/ext/auth.py
+++ b/src/air/ext/auth.py
@@ -1,0 +1,53 @@
+from collections.abc import Callable
+
+from authlib.integrations.starlette_client import OAuth
+
+from ..exceptions import HTTPException
+from ..requests import Request
+from ..responses import RedirectResponse
+from ..routing import AirRouter
+
+
+def _check_session_middleware(request: Request):
+    """Confirms the session middleware is installed, raises a 500 exception if it is not.
+
+    TODO: Turn into a dependency, put in the dependencies.py module as `check_session_middleware`
+    """
+    if not hasattr(request, "session"):
+        raise HTTPException(status_code=500, detail="Session middleware not installed.")
+
+
+def GitHubOAuthRouterFactory(
+    github_client_id: str, github_client_secret: str, github_process_callable: Callable, login_redirect_to: str = "/"
+) -> AirRouter:
+    router = AirRouter()
+    oauth = OAuth()
+    oauth.register(
+        name="github",
+        client_id=github_client_id,
+        client_secret=github_client_secret,
+        access_token_url="https://github.com/login/oauth/access_token",
+        access_token_params=None,
+        authorize_url="https://github.com/login/oauth/authorize",
+        authorize_params=None,
+        api_base_url="https://api.github.com/",
+        client_kwargs={"scope": "user:email"},
+    )
+    github = oauth.create_client("github")
+
+    @router.get("/account/github/login")
+    async def github_login(request: Request):
+        _check_session_middleware(request)
+        redirect_uri = request.url_for("github_callback")
+        return await github.authorize_redirect(request, redirect_uri)
+
+    @router.get("/account/github/callback")
+    async def github_callback(request: Request):
+        _check_session_middleware(request)
+        token = await oauth.github.authorize_access_token(request)
+
+        await github_process_callable(request=request, token=token)
+
+        return RedirectResponse(login_redirect_to)
+
+    return router

--- a/src/air/ext/auth.py
+++ b/src/air/ext/auth.py
@@ -80,19 +80,9 @@ from collections.abc import Callable
 
 from authlib.integrations.starlette_client import OAuth
 
-from ..exceptions import HTTPException
 from ..requests import Request
 from ..responses import RedirectResponse
 from ..routing import AirRouter
-
-
-def _check_session_middleware(request: Request):
-    """Confirms the session middleware is installed, raises a 500 exception if it is not.
-
-    TODO: Turn into a dependency, put in the dependencies.py module as `check_session_middleware`
-    """
-    if not hasattr(request, "session"):
-        raise HTTPException(status_code=500, detail="Session middleware not installed.")
 
 
 def GitHubOAuthRouterFactory(
@@ -125,13 +115,13 @@ def GitHubOAuthRouterFactory(
 
     @router.get("/account/github/login")
     async def github_login(request: Request):
-        _check_session_middleware(request)
+        assert hasattr(request, "session")
         redirect_uri = request.url_for("github_callback")
         return await github.authorize_redirect(request, redirect_uri)
 
     @router.get("/account/github/callback")
     async def github_callback(request: Request):
-        _check_session_middleware(request)
+        assert hasattr(request, "session")
         token = await oauth.github.authorize_access_token(request)
 
         await github_process_callable(request=request, token=token)

--- a/src/air/ext/auth.py
+++ b/src/air/ext/auth.py
@@ -1,3 +1,81 @@
+"""
+Implementing the User model with GitHub OAuth.
+
+!!! note "Coming Soon: More authentication methods!"
+    We chose GitHub OAuth because configuring it is straightforward. Our plan is to expand to other OAuth providers as well as other registration and authentication mechanisms.
+# Setup
+
+## Step 1: Get client ID and secret
+
+TODO: Add instructions on getting this from GitHub
+
+!!! warning "Client secrets must be protected!"
+    Do not store client secrets in your repo. This is what connects your application to GitHub, and if bad guys find it they can cause problem for you and your users. Instead, use environment variables or other proven methods for securing private credentials.
+
+
+## Step 2: Write a Github Process callable to process the user when the come back from github
+
+This is a simple in-memory version, you want to save this to a database, either SQL or non-SQL.
+
+```python
+import air
+
+database = {}
+
+
+async def github_process_callable(request: air.Request, token: dict, client: str = "") -> None:
+    access_token = token["access_token"]
+    print(access_token)
+    if access_token in database:
+        database[access_token]["updated_at"] = datetime.now()
+    else:
+        database[access_token] = token
+        database[access_token]["created_at"] = datetime.now()
+        database[access_token]["updated_at"] = datetime.now()
+        database[access_token]["access_token"] = access_token
+    request.session["github_access_token"] = access_token
+    print(database)
+```
+
+## Step 3: Use the GitHubOAuthRouterFactory to generate your OAuth router
+
+```python
+github_oauth_router = air.ext.GitHubOAuthRouterFactory(
+    github_client_id=environ["GITHUB_CLIENT_ID"],
+    github_client_secret=environ["GITHUB_CLIENT_SECRET"],
+    github_process_callable=github_process_callable,
+    login_redirect_to="/",
+)
+```
+
+
+## Step 4: Code up the rest of the project
+
+
+```python
+import air
+
+app = air.Air()
+app.add_middleware(air.SessionMiddleware, secret_key="change-me")
+# We created github_oauth_router in step 3
+app.include_router(github_oauth_router)
+
+
+@app.page
+async def index(request: air.Request):
+    return air.layouts.mvpcss(
+        air.H1("GitHub OAuth Login Demo"),
+        air.P(air.A("Login to Github", href="/account/github/login")),
+        air.P(request.session.get("github_access_token", "Not authenticated yet")),
+    )
+```
+
+Try it out!
+
+---
+
+"""
+
 from collections.abc import Callable
 
 from authlib.integrations.starlette_client import OAuth
@@ -20,6 +98,16 @@ def _check_session_middleware(request: Request):
 def GitHubOAuthRouterFactory(
     github_client_id: str, github_client_secret: str, github_process_callable: Callable, login_redirect_to: str = "/"
 ) -> AirRouter:
+    """Creates an `air.AirRouter` affiliated with the supplied credentials.
+
+    TODO: Create a type or formal definition for the process callable
+
+    ARGS:
+        github_client_id: The GitHub client ID.
+        github_client_secret: The GitHub client secret. Do not include this in your repo, use environment variables!
+        github_process_callable: A callable (function, class, or method) that takes three arguments, request, token, and client
+        login_redirect_to: The path to send the user to once they have authenticated
+    """
     router = AirRouter()
     oauth = OAuth()
     oauth.register(

--- a/tests/ext/test_auth.py
+++ b/tests/ext/test_auth.py
@@ -1,0 +1,47 @@
+import pytest
+from fastapi.testclient import TestClient
+
+import air
+
+
+def test_app_has_session():
+    async def github_process_callable(request: air.Request, token: dict, client: str = "") -> None:
+        pass
+
+    github_oauth_router = air.ext.GitHubOAuthRouterFactory(
+        github_client_id="CLIENT_ID",
+        github_client_secret="CLIENT_SECRET",
+        github_process_callable=github_process_callable,
+        login_redirect_to="/",
+    )
+
+    app = air.Air()
+    app.include_router(github_oauth_router)
+
+    client = TestClient(app)
+    with pytest.raises(AssertionError):
+        client.get("/account/github/login")
+
+
+def test_github_login_route():
+    async def github_process_callable(request: air.Request, token: dict, client: str = "") -> None:
+        pass
+
+    github_oauth_router = air.ext.GitHubOAuthRouterFactory(
+        github_client_id="CLIENT_ID",
+        github_client_secret="CLIENT_SECRET",
+        github_process_callable=github_process_callable,
+        login_redirect_to="/",
+    )
+
+    app = air.Air()
+    app.add_middleware(air.SessionMiddleware, secret_key="insecure")
+    app.include_router(github_oauth_router)
+
+    client = TestClient(app)
+    response = client.get("/account/github/login")
+
+    assert response.history[0].status_code == 302
+    assert response.headers["content-type"] == "text/html; charset=utf-8"
+    assert response._request.url.host == "github.com"  # ty:ignore[possibly-unbound-attribute]
+    assert response._request.url.path == "/login/oauth/authorize"  # ty:ignore[possibly-unbound-attribute]

--- a/uv.lock
+++ b/uv.lock
@@ -37,6 +37,9 @@ dependencies = [
 ]
 
 [package.optional-dependencies]
+auth = [
+    { name = "authlib" },
+]
 pretty = [
     { name = "lxml" },
     { name = "rich", version = "12.6.0", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'group-3-air-dev' or extra == 'group-3-air-devtools'" },
@@ -128,6 +131,7 @@ test = [
 
 [package.metadata]
 requires-dist = [
+    { name = "authlib", marker = "extra == 'auth'", specifier = ">=1.6.3" },
     { name = "fastapi", specifier = ">=0.116.1" },
     { name = "fastapi", extras = ["standard"], marker = "extra == 'standard'", specifier = ">=0.116.1" },
     { name = "greenlet", marker = "extra == 'sql'", specifier = ">=3.2.4" },
@@ -138,7 +142,7 @@ requires-dist = [
     { name = "rich", marker = "extra == 'pretty'", specifier = ">=12.6.0" },
     { name = "sqlmodel", marker = "extra == 'sql'", specifier = ">=0.0.24" },
 ]
-provides-extras = ["standard", "pretty", "sql"]
+provides-extras = ["standard", "pretty", "sql", "auth"]
 
 [package.metadata.requires-dev]
 dev = [
@@ -265,6 +269,18 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/5a/b0/1367933a8532ee6ff8d63537de4f1177af4bff9f3e829baf7331f595bb24/attrs-25.3.0.tar.gz", hash = "sha256:75d7cefc7fb576747b2c81b4442d4d4a1ce0900973527c011d1030fd3bf4af1b", size = 812032, upload-time = "2025-03-13T11:10:22.779Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/77/06/bb80f5f86020c4551da315d78b3ab75e8228f89f0162f2c3a819e407941a/attrs-25.3.0-py3-none-any.whl", hash = "sha256:427318ce031701fea540783410126f03899a97ffc6f61596ad581ac2e40e3bc3", size = 63815, upload-time = "2025-03-13T11:10:21.14Z" },
+]
+
+[[package]]
+name = "authlib"
+version = "1.6.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cryptography" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5d/c6/d9a9db2e71957827e23a34322bde8091b51cb778dcc38885b84c772a1ba9/authlib-1.6.3.tar.gz", hash = "sha256:9f7a982cc395de719e4c2215c5707e7ea690ecf84f1ab126f28c053f4219e610", size = 160836, upload-time = "2025-08-26T12:13:25.206Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/25/2f/efa9d26dbb612b774990741fd8f13c7cf4cfd085b870e4a5af5c82eaf5f1/authlib-1.6.3-py2.py3-none-any.whl", hash = "sha256:7ea0f082edd95a03b7b72edac65ec7f8f68d703017d7e37573aee4fc603f2a48", size = 240105, upload-time = "2025-08-26T12:13:23.889Z" },
 ]
 
 [[package]]
@@ -592,6 +608,56 @@ wheels = [
 [package.optional-dependencies]
 toml = [
     { name = "tomli", marker = "python_full_version <= '3.11' or (extra == 'extra-3-air-standard' and extra == 'group-3-air-dev') or (extra == 'extra-3-air-standard' and extra == 'group-3-air-devtools')" },
+]
+
+[[package]]
+name = "cryptography"
+version = "46.0.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cffi", marker = "platform_python_implementation != 'PyPy' or (extra == 'extra-3-air-standard' and extra == 'group-3-air-dev') or (extra == 'extra-3-air-standard' and extra == 'group-3-air-devtools')" },
+    { name = "typing-extensions", marker = "python_full_version < '3.11' or (extra == 'extra-3-air-standard' and extra == 'group-3-air-dev') or (extra == 'extra-3-air-standard' and extra == 'group-3-air-devtools')" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a9/62/e3664e6ffd7743e1694b244dde70b43a394f6f7fbcacf7014a8ff5197c73/cryptography-46.0.1.tar.gz", hash = "sha256:ed570874e88f213437f5cf758f9ef26cbfc3f336d889b1e592ee11283bb8d1c7", size = 749198, upload-time = "2025-09-17T00:10:35.797Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4c/8c/44ee01267ec01e26e43ebfdae3f120ec2312aa72fa4c0507ebe41a26739f/cryptography-46.0.1-cp311-abi3-macosx_10_9_universal2.whl", hash = "sha256:1cd6d50c1a8b79af1a6f703709d8973845f677c8e97b1268f5ff323d38ce8475", size = 7285044, upload-time = "2025-09-17T00:08:36.807Z" },
+    { url = "https://files.pythonhosted.org/packages/22/59/9ae689a25047e0601adfcb159ec4f83c0b4149fdb5c3030cc94cd218141d/cryptography-46.0.1-cp311-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:0ff483716be32690c14636e54a1f6e2e1b7bf8e22ca50b989f88fa1b2d287080", size = 4308182, upload-time = "2025-09-17T00:08:39.388Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/ee/ca6cc9df7118f2fcd142c76b1da0f14340d77518c05b1ebfbbabca6b9e7d/cryptography-46.0.1-cp311-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:9873bf7c1f2a6330bdfe8621e7ce64b725784f9f0c3a6a55c3047af5849f920e", size = 4572393, upload-time = "2025-09-17T00:08:41.663Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/a3/0f5296f63815d8e985922b05c31f77ce44787b3127a67c0b7f70f115c45f/cryptography-46.0.1-cp311-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:0dfb7c88d4462a0cfdd0d87a3c245a7bc3feb59de101f6ff88194f740f72eda6", size = 4308400, upload-time = "2025-09-17T00:08:43.559Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/8c/74fcda3e4e01be1d32775d5b4dd841acaac3c1b8fa4d0774c7ac8d52463d/cryptography-46.0.1-cp311-abi3-manylinux_2_28_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:e22801b61613ebdebf7deb18b507919e107547a1d39a3b57f5f855032dd7cfb8", size = 4015786, upload-time = "2025-09-17T00:08:45.758Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/b8/85d23287baeef273b0834481a3dd55bbed3a53587e3b8d9f0898235b8f91/cryptography-46.0.1-cp311-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:757af4f6341ce7a1e47c326ca2a81f41d236070217e5fbbad61bbfe299d55d28", size = 4982606, upload-time = "2025-09-17T00:08:47.602Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/d3/de61ad5b52433b389afca0bc70f02a7a1f074651221f599ce368da0fe437/cryptography-46.0.1-cp311-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:f7a24ea78de345cfa7f6a8d3bde8b242c7fac27f2bd78fa23474ca38dfaeeab9", size = 4604234, upload-time = "2025-09-17T00:08:49.879Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/1f/dbd4d6570d84748439237a7478d124ee0134bf166ad129267b7ed8ea6d22/cryptography-46.0.1-cp311-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:9e8776dac9e660c22241b6587fae51a67b4b0147daa4d176b172c3ff768ad736", size = 4307669, upload-time = "2025-09-17T00:08:52.321Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/fd/ca0a14ce7f0bfe92fa727aacaf2217eb25eb7e4ed513b14d8e03b26e63ed/cryptography-46.0.1-cp311-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:9f40642a140c0c8649987027867242b801486865277cbabc8c6059ddef16dc8b", size = 4947579, upload-time = "2025-09-17T00:08:54.697Z" },
+    { url = "https://files.pythonhosted.org/packages/89/6b/09c30543bb93401f6f88fce556b3bdbb21e55ae14912c04b7bf355f5f96c/cryptography-46.0.1-cp311-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:449ef2b321bec7d97ef2c944173275ebdab78f3abdd005400cc409e27cd159ab", size = 4603669, upload-time = "2025-09-17T00:08:57.16Z" },
+    { url = "https://files.pythonhosted.org/packages/23/9a/38cb01cb09ce0adceda9fc627c9cf98eb890fc8d50cacbe79b011df20f8a/cryptography-46.0.1-cp311-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:2dd339ba3345b908fa3141ddba4025568fa6fd398eabce3ef72a29ac2d73ad75", size = 4435828, upload-time = "2025-09-17T00:08:59.606Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/53/435b5c36a78d06ae0bef96d666209b0ecd8f8181bfe4dda46536705df59e/cryptography-46.0.1-cp311-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:7411c910fb2a412053cf33cfad0153ee20d27e256c6c3f14d7d7d1d9fec59fd5", size = 4709553, upload-time = "2025-09-17T00:09:01.832Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/c4/0da6e55595d9b9cd3b6eb5dc22f3a07ded7f116a3ea72629cab595abb804/cryptography-46.0.1-cp311-abi3-win32.whl", hash = "sha256:cbb8e769d4cac884bb28e3ff620ef1001b75588a5c83c9c9f1fdc9afbe7f29b0", size = 3058327, upload-time = "2025-09-17T00:09:03.726Z" },
+    { url = "https://files.pythonhosted.org/packages/95/0f/cd29a35e0d6e78a0ee61793564c8cff0929c38391cb0de27627bdc7525aa/cryptography-46.0.1-cp311-abi3-win_amd64.whl", hash = "sha256:92e8cfe8bd7dd86eac0a677499894862cd5cc2fd74de917daa881d00871ac8e7", size = 3523893, upload-time = "2025-09-17T00:09:06.272Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/dd/eea390f3e78432bc3d2f53952375f8b37cb4d37783e626faa6a51e751719/cryptography-46.0.1-cp311-abi3-win_arm64.whl", hash = "sha256:db5597a4c7353b2e5fb05a8e6cb74b56a4658a2b7bf3cb6b1821ae7e7fd6eaa0", size = 2932145, upload-time = "2025-09-17T00:09:08.568Z" },
+    { url = "https://files.pythonhosted.org/packages/98/e5/fbd632385542a3311915976f88e0dfcf09e62a3fc0aff86fb6762162a24d/cryptography-46.0.1-cp38-abi3-macosx_10_9_universal2.whl", hash = "sha256:d84c40bdb8674c29fa192373498b6cb1e84f882889d21a471b45d1f868d8d44b", size = 7255677, upload-time = "2025-09-17T00:09:42.407Z" },
+    { url = "https://files.pythonhosted.org/packages/56/3e/13ce6eab9ad6eba1b15a7bd476f005a4c1b3f299f4c2f32b22408b0edccf/cryptography-46.0.1-cp38-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:9ed64e5083fa806709e74fc5ea067dfef9090e5b7a2320a49be3c9df3583a2d8", size = 4301110, upload-time = "2025-09-17T00:09:45.614Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/67/65dc233c1ddd688073cf7b136b06ff4b84bf517ba5529607c9d79720fc67/cryptography-46.0.1-cp38-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:341fb7a26bc9d6093c1b124b9f13acc283d2d51da440b98b55ab3f79f2522ead", size = 4562369, upload-time = "2025-09-17T00:09:47.601Z" },
+    { url = "https://files.pythonhosted.org/packages/17/db/d64ae4c6f4e98c3dac5bf35dd4d103f4c7c345703e43560113e5e8e31b2b/cryptography-46.0.1-cp38-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:6ef1488967e729948d424d09c94753d0167ce59afba8d0f6c07a22b629c557b2", size = 4302126, upload-time = "2025-09-17T00:09:49.335Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/19/5f1eea17d4805ebdc2e685b7b02800c4f63f3dd46cfa8d4c18373fea46c8/cryptography-46.0.1-cp38-abi3-manylinux_2_28_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:7823bc7cdf0b747ecfb096d004cc41573c2f5c7e3a29861603a2871b43d3ef32", size = 4009431, upload-time = "2025-09-17T00:09:51.239Z" },
+    { url = "https://files.pythonhosted.org/packages/81/b5/229ba6088fe7abccbfe4c5edb96c7a5ad547fac5fdd0d40aa6ea540b2985/cryptography-46.0.1-cp38-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:f736ab8036796f5a119ff8211deda416f8c15ce03776db704a7a4e17381cb2ef", size = 4980739, upload-time = "2025-09-17T00:09:54.181Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/9c/50aa38907b201e74bc43c572f9603fa82b58e831bd13c245613a23cff736/cryptography-46.0.1-cp38-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:e46710a240a41d594953012213ea8ca398cd2448fbc5d0f1be8160b5511104a0", size = 4592289, upload-time = "2025-09-17T00:09:56.731Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/33/229858f8a5bb22f82468bb285e9f4c44a31978d5f5830bb4ea1cf8a4e454/cryptography-46.0.1-cp38-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:84ef1f145de5aee82ea2447224dc23f065ff4cc5791bb3b506615957a6ba8128", size = 4301815, upload-time = "2025-09-17T00:09:58.548Z" },
+    { url = "https://files.pythonhosted.org/packages/52/cb/b76b2c87fbd6ed4a231884bea3ce073406ba8e2dae9defad910d33cbf408/cryptography-46.0.1-cp38-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:9394c7d5a7565ac5f7d9ba38b2617448eba384d7b107b262d63890079fad77ca", size = 4943251, upload-time = "2025-09-17T00:10:00.475Z" },
+    { url = "https://files.pythonhosted.org/packages/94/0f/f66125ecf88e4cb5b8017ff43f3a87ede2d064cb54a1c5893f9da9d65093/cryptography-46.0.1-cp38-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:ed957044e368ed295257ae3d212b95456bd9756df490e1ac4538857f67531fcc", size = 4591247, upload-time = "2025-09-17T00:10:02.874Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/22/9f3134ae436b63b463cfdf0ff506a0570da6873adb4bf8c19b8a5b4bac64/cryptography-46.0.1-cp38-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:f7de12fa0eee6234de9a9ce0ffcfa6ce97361db7a50b09b65c63ac58e5f22fc7", size = 4428534, upload-time = "2025-09-17T00:10:04.994Z" },
+    { url = "https://files.pythonhosted.org/packages/89/39/e6042bcb2638650b0005c752c38ea830cbfbcbb1830e4d64d530000aa8dc/cryptography-46.0.1-cp38-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:7fab1187b6c6b2f11a326f33b036f7168f5b996aedd0c059f9738915e4e8f53a", size = 4699541, upload-time = "2025-09-17T00:10:06.925Z" },
+    { url = "https://files.pythonhosted.org/packages/68/46/753d457492d15458c7b5a653fc9a84a1c9c7a83af6ebdc94c3fc373ca6e8/cryptography-46.0.1-cp38-abi3-win32.whl", hash = "sha256:45f790934ac1018adeba46a0f7289b2b8fe76ba774a88c7f1922213a56c98bc1", size = 3043779, upload-time = "2025-09-17T00:10:08.951Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/50/b6f3b540c2f6ee712feeb5fa780bb11fad76634e71334718568e7695cb55/cryptography-46.0.1-cp38-abi3-win_amd64.whl", hash = "sha256:7176a5ab56fac98d706921f6416a05e5aff7df0e4b91516f450f8627cda22af3", size = 3517226, upload-time = "2025-09-17T00:10:10.769Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/e8/77d17d00981cdd27cc493e81e1749a0b8bbfb843780dbd841e30d7f50743/cryptography-46.0.1-cp38-abi3-win_arm64.whl", hash = "sha256:efc9e51c3e595267ff84adf56e9b357db89ab2279d7e375ffcaf8f678606f3d9", size = 2923149, upload-time = "2025-09-17T00:10:13.236Z" },
+    { url = "https://files.pythonhosted.org/packages/14/b9/b260180b31a66859648cfed5c980544ee22b15f8bd20ef82a23f58c0b83e/cryptography-46.0.1-pp310-pypy310_pp73-macosx_10_9_x86_64.whl", hash = "sha256:fd4b5e2ee4e60425711ec65c33add4e7a626adef79d66f62ba0acfd493af282d", size = 3714683, upload-time = "2025-09-17T00:10:15.601Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/5a/1cd3ef86e5884edcbf8b27c3aa8f9544e9b9fcce5d3ed8b86959741f4f8e/cryptography-46.0.1-pp310-pypy310_pp73-win_amd64.whl", hash = "sha256:48948940d0ae00483e85e9154bb42997d0b77c21e43a77b7773c8c80de532ac5", size = 3443784, upload-time = "2025-09-17T00:10:18.014Z" },
+    { url = "https://files.pythonhosted.org/packages/27/27/077e09fd92075dd1338ea0ffaf5cfee641535545925768350ad90d8c36ca/cryptography-46.0.1-pp311-pypy311_pp73-macosx_10_9_x86_64.whl", hash = "sha256:b9c79af2c3058430d911ff1a5b2b96bbfe8da47d5ed961639ce4681886614e70", size = 3722319, upload-time = "2025-09-17T00:10:20.273Z" },
+    { url = "https://files.pythonhosted.org/packages/db/32/6fc7250280920418651640d76cee34d91c1e0601d73acd44364570cf041f/cryptography-46.0.1-pp311-pypy311_pp73-manylinux_2_28_aarch64.whl", hash = "sha256:0ca4be2af48c24df689a150d9cd37404f689e2968e247b6b8ff09bff5bcd786f", size = 4249030, upload-time = "2025-09-17T00:10:22.396Z" },
+    { url = "https://files.pythonhosted.org/packages/32/33/8d5398b2da15a15110b2478480ab512609f95b45ead3a105c9a9c76f9980/cryptography-46.0.1-pp311-pypy311_pp73-manylinux_2_28_x86_64.whl", hash = "sha256:13e67c4d3fb8b6bc4ef778a7ccdd8df4cd15b4bcc18f4239c8440891a11245cc", size = 4528009, upload-time = "2025-09-17T00:10:24.418Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/1c/4012edad2a8977ab386c36b6e21f5065974d37afa3eade83a9968cba4855/cryptography-46.0.1-pp311-pypy311_pp73-manylinux_2_34_aarch64.whl", hash = "sha256:15b5fd9358803b0d1cc42505a18d8bca81dabb35b5cfbfea1505092e13a9d96d", size = 4248902, upload-time = "2025-09-17T00:10:26.255Z" },
+    { url = "https://files.pythonhosted.org/packages/58/a3/257cd5ae677302de8fa066fca9de37128f6729d1e63c04dd6a15555dd450/cryptography-46.0.1-pp311-pypy311_pp73-manylinux_2_34_x86_64.whl", hash = "sha256:e34da95e29daf8a71cb2841fd55df0511539a6cdf33e6f77c1e95e44006b9b46", size = 4527150, upload-time = "2025-09-17T00:10:28.28Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/cd/fe6b65e1117ec7631f6be8951d3db076bac3e1b096e3e12710ed071ffc3c/cryptography-46.0.1-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:34f04b7311174469ab3ac2647469743720f8b6c8b046f238e5cb27905695eb2a", size = 3448210, upload-time = "2025-09-17T00:10:30.145Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
This makes it possible to have easy configuration for AIR anyway that you want. Just provide three things:

- GitHub client id
- Github client secret
- A processing function for when the callback is triggered

Tasks:

- [x] Code
- [x] Docs
- [x] Demo
- [x] Tests

Supersedes #417