### PR TITLE
Change air.db.sql to air.ext.sql

### DIFF
--- a/docs/learn/sql.md
+++ b/docs/learn/sql.md
@@ -22,7 +22,7 @@ import air
 
 @asynccontextmanager
 async def lifespan(app: air.Air):
-    async_engine = air.db.sql.create_async_engine()
+    async_engine = air.ext.sql.create_async_engine()
     async with async_engine.begin() as conn:
         await conn.run_sync(lambda _: None)    
     yield


### PR DESCRIPTION
# Issue(s)

Fixes #460

## Description

Fixed incorrect module reference in SQL documentation. Changed `air.db.sql` to `air.ext.sql` in the code example within `docs/learn/sql.md` to match the correct module structure.

The bug was causing confusion for users trying to work with persistence as the documentation referenced a non-existent module path. This change ensures the documentation example works correctly with the actual Air codebase.

## Pull request type

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] New feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [x] Documentation content changes
- [ ] Other (please describe):

## Pull request tasks

The following have been completed for this task:

- [ ] Code changes
- [x] Documentation changes for new or changed features
- [ ] Alterations of behavior come with a working implementation in the `examples` folder
- [ ] Tests on new or altered behaviors

## Demo or screenshot

N/A - This is a documentation fix for a single line change from `air.db.sql.create_async_engine()` to `air.ext.sql.create_async_engine()`.

## Checklist

- [ ] I have run `just test` and `just qa`, ensuring my code changes passes all existing tests
- [x] I have performed a self-review of my own code
- [ ] I have ensured that there are tests to cover my changes

## Other information

This is a simple documentation correction that ensures users can successfully follow the SQL configuration example. The change aligns the documentation with the actual module structure found in `src/air/ext/sql.py`.