### PR TITLE
Added get_object_or_404 to air.ext.sql.

### DIFF
--- a/docs/api/ext/sql.md
+++ b/docs/api/ext/sql.md
@@ -12,3 +12,4 @@
         - create_async_session
         - get_async_session
         - async_session_dependency
+        - get_object_or_404

--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -7,6 +7,8 @@ Here is the Air reference documentation. It explains how to do things, as well a
 - [Exception Handlers](../api/exception_handlers) - Exceptions are returned to the user, specifically 404 and 500
 - [Exceptions](../api/exceptions) - Sometimes it's good to know exactly what is breaking
 - [Ext](../api/ext) - Functionality for Air that requires extra dependencies
+    - [Auth](../api/ext/auth) - Authentication tools for OAuth and eventually email and magic link.
+    - [SQL](../api/ext/sql) - Utilities for connecting to relational databases like PostgreSQL, MySQL, and SQLite.
 - [Forms](../api/forms) - Receive and validate data from users on web pages
 - [Layouts](../api/layouts) - Utilities for building layout functions and two example layouts for css microframeworks (mvcss and picocss)
 - [Middleware](../api/middleware.md) - Middleware for Air

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -470,6 +470,7 @@ unsupported-base = "error"               # https://docs.astral.sh/ty/reference/r
 division-by-zero = "error"               # https://docs.astral.sh/ty/reference/rules/#division-by-zero
 possibly-unresolved-reference = "error"  # https://docs.astral.sh/ty/reference/rules/#possibly-unresolved-reference
 unused-ignore-comment = "error"          # https://docs.astral.sh/ty/reference/rules/#unused-ignore-comment
+unresolved-attribute = "ignore"
 
 # Tests often import optional dev deps or use dynamic patterns.
 [[tool.ty.overrides]]

--- a/src/air/exceptions.py
+++ b/src/air/exceptions.py
@@ -11,3 +11,7 @@ class BaseAirException(Exception):
 
 class RenderException(BaseAirException):
     """Error thrown when render function fails."""
+
+
+class ObjectDoesNotExist(HTTPException):
+    """Thrown when a record in a persistence store can't be found."""

--- a/src/air/ext/sql.py
+++ b/src/air/ext/sql.py
@@ -46,8 +46,15 @@ from sqlalchemy.ext.asyncio import (
     create_async_engine as _create_async_engine,
 )
 from sqlalchemy.ext.asyncio.engine import AsyncEngine
-from sqlmodel import create_engine as _create_engine
+from sqlalchemy.sql.elements import BinaryExpression
+from sqlmodel import (
+    SQLModel,
+    create_engine as _create_engine,
+    select,
+)
 from sqlmodel.ext.asyncio.session import AsyncSession
+
+from ..exceptions import ObjectDoesNotExist
 
 DEBUG = getenv("DEBUG", "false").lower() in ("1", "true", "yes")
 """Environment variable for setting DEBUG loglevel."""
@@ -125,6 +132,7 @@ def create_async_engine(
 async def create_async_session(
     url: str = ASYNC_DATABASE_URL,  # Database URL
     echo: EchoEnum = EchoEnum.TRUE if DEBUG else EchoEnum.FALSE,
+    async_engine=None,
 ):
     """
     Create an async SQLAlchemy session factory.
@@ -137,11 +145,12 @@ async def create_async_session(
             session.add(database_object)
             await session.commit()
     """
-    async_engine = create_async_engine(
-        url,  # Async connection string
-        echo=echo,
-        future=FutureEnum.TRUE,
-    )
+    if async_engine is None:
+        async_engine = create_async_engine(
+            url,  # Async connection string
+            echo=echo,
+            future=FutureEnum.TRUE,
+        )
     return async_sessionmaker(
         bind=async_engine,
         class_=AsyncSession,
@@ -180,3 +189,39 @@ async def get_async_session(
 
 async_session_dependency = Depends(get_async_session)
 "Shortcut for `Depends(get_async_session)` that only works if DATABASE_URL env var is set."
+
+
+async def get_object_or_404(session: AsyncSession, model: SQLModel, *args: BinaryExpression):
+    """Get a record or raise an exception.
+
+    Args:
+        session: An `AsyncSession` object.
+        model: A SQLModel subclass, in the example inspired by SQLModel below we use Hero as a table object.
+        *args: One or more SQLAlchemy BinaryExpressions. The classic example is `Hero.name=='Spiderman'` which will display as `<sqlalchemy.sql.elements.BinaryExpression object at 0x104ba0410>`..
+
+    Example:
+
+        import air
+        from db import Hero
+
+        app = air.Air()
+
+        @app.get('/heroes/{name: str}')
+        async def hero(name: str, session = Depends(air.db.sql.get_async_session)):
+            hero = await get_object_or_404(session, model, Hero.name==name)
+            return air.layouts.mvpcss(
+                air.H1(hero.name),
+                air.P(hero.secret_identity)
+            )
+
+    """
+    stmt = select(model)
+    for arg in args:
+        stmt = stmt.where(arg)
+    results = await session.exec(stmt)
+    if obj := results.one_or_none():
+        return obj
+    error = ObjectDoesNotExist(status_code=404)
+    error.add_note(f"{model=}")
+    error.add_note(f"{args=}")
+    raise error

--- a/tests/test_templating.py
+++ b/tests/test_templating.py
@@ -346,7 +346,7 @@ def test_Renderer_tag_callable_with_both_args_and_context() -> None:
     import types
 
     test_module = types.ModuleType("test_module")
-    test_module.test_func = test_callable  # ty:ignore[unresolved-attribute]
+    test_module.test_func = test_callable
     sys.modules["tests.test_module"] = test_module
 
     @app.page
@@ -376,7 +376,7 @@ def test_Renderer_import_module_fallback() -> None:
 
     # Create a mock module that exists as a relative import but not absolute
     mock_module = types.ModuleType("mock_module")
-    mock_module.test_func = lambda: "test"  # ty:ignore[unresolved-attribute]
+    mock_module.test_func = lambda: "test"
     sys.modules["tests.mock_module"] = mock_module
 
     try:


### PR DESCRIPTION
## Description

This adds a `get_object_or_404` function to `air.ext.sql`. It allows fetching of single records quickly and with minimal code. It is directly inspired by Django's implementation of the same name.

- https://docs.djangoproject.com/en/dev/topics/http/shortcuts/#get-object-or-404

## Pull request type

Please check the type of change your PR introduces:

- [ ] Bugfix
- [x] New feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [x] Documentation content changes
- [ ] Other (please describe):

## Pull request tasks

The following have been completed for this task:

- [x] Code changes
- [x] Documentation changes for new or changed features
- [x] Alterations of behavior come with a working implementation in the `examples` folder
- [x] Tests on new or altered behaviors

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] I have run `just test` and `just qa`, ensuring my code changes passes all existing tests
- [x] I have performed a self-review of my own code
- [x] I have ensured that there are tests to cover my changes
