### PR TITLE
Drop support for python 3.10

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -69,7 +69,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ ubuntu-latest, windows-latest, macos-latest ]
-        python-version: [ "3.10","3.11","3.12","3.13" ]
+        python-version: ["3.11","3.12","3.13" ]
     name: Tests • ${{ matrix.os }} • Python ${{ matrix.python-version }} (via just, uv, pytest, pytest-pretty)
     runs-on: ${{ matrix.os }}
     timeout-minutes: 45

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -37,7 +37,7 @@ Now you're ready to run Air from your local clone of your fork. Play with it, fi
 - Run any tool in the venv (auto-syncs):
   `uv run <command>`
 
-If your Python is older than 3.13, don't worry! uv will automatically install Python 3.13 just for this project, the library does work on Python 3.10->3.13, but dev tools (group `dev`) are pinned to Python 3.13+ to keep the toolchain modern.
+If your Python is older than 3.13, don't worry! uv will automatically install Python 3.13 just for this project, the library does work on Python 3.11->3.13, but dev tools (group `dev`) are pinned to Python 3.13+ to keep the toolchain modern.
 
 ---
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ authors = [
 ]
 readme = "README.md"
 license = { file = "LICENSE" }
-requires-python = ">=3.10,<3.14"
+requires-python = ">=3.11,<3.14"
 urls.Homepage = "https://github.com/feldroy/air"
 urls.Docs = "https://feldroy.github.io/air/"
 urls.Issues = "https://github.com/feldroy/air/issues"
@@ -29,7 +29,6 @@ classifiers = [
     "Framework :: FastAPI",
     "Intended Audience :: Developers",
     "Programming Language :: Python :: 3 :: Only",
-    "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",

--- a/src/air/background.py
+++ b/src/air/background.py
@@ -1,10 +1,10 @@
 """Background tasks in Air, for those times a long-running process is needed that doesn't force the user to wait."""
 
 from collections.abc import Callable
-from typing import Annotated
+from typing import Annotated, Any
 
 from fastapi.background import BackgroundTasks as FastAPIBackgroundTasks
-from typing_extensions import Any, Doc, ParamSpec
+from typing_extensions import Doc, ParamSpec
 
 P = ParamSpec("P")
 

--- a/src/air/forms.py
+++ b/src/air/forms.py
@@ -4,7 +4,7 @@ Pro-tip: Always validate incoming data."""
 
 from collections.abc import Callable, Sequence
 from types import UnionType
-from typing import Any, Union, get_args, get_origin
+from typing import Any, Self, Union, get_args, get_origin
 
 from pydantic import BaseModel, Field, ValidationError
 from pydantic_core import ErrorDetails
@@ -13,13 +13,6 @@ from starlette.datastructures import FormData
 from . import tags
 from .requests import Request
 from .tags import SafeStr
-
-try:  # pragma: no cover
-    # Remove this try/except statement once support for Python 3.10 is dropped
-    # Then we can do just this immediate line below
-    from typing import Self  # Python 3.11+
-except ImportError:  # pragma: no cover
-    from typing_extensions import Self
 
 
 class AirForm:

--- a/src/air/tags/models/base.py
+++ b/src/air/tags/models/base.py
@@ -7,12 +7,7 @@ import json
 from collections.abc import Mapping
 from functools import cached_property
 from types import MappingProxyType
-from typing import Any, ClassVar, Final, TypedDict
-
-try:
-    from typing import Self
-except ImportError:
-    from typing_extensions import Self
+from typing import Any, ClassVar, Final, Self, TypedDict
 
 from ..utils import SafeStr, clean_html_attr_key, format_html
 


### PR DESCRIPTION
# Issue(s)

#398 

## Description

Drops support for Python 3.10 as it not only cleans up a few logic branches but allows us to use `Exception.add_note`.

## Pull request type


Please check the type of change your PR introduces:

- [ ] Bugfix
- [ ] New feature
- [ ] Refactoring (no functional changes, no api changes)
- [x] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): Version up

## Pull request tasks

The following have been completed for this task:

- [x] Code changes
- [x] Documentation changes for new or changed features
- [ ] Alterations of behavior come with a working implementation in the `examples` folder
- [ ] Tests on new or altered behaviors


## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] I have run `just test` and `just qa`, ensuring my code changes passes all existing tests
- [x] I have performed a self-review of my own code
- [x] I have ensured that there are tests to cover my changes
