### PR TITLE
format_html improvements

### DIFF
--- a/examples/tags_render.py
+++ b/examples/tags_render.py
@@ -12,32 +12,10 @@ Run:
 
 from __future__ import annotations
 
-from rich import box, print
-from rich.console import Console
-from rich.padding import Padding
-from rich.panel import Panel
-from rich.syntax import Syntax
+from rich import print
 
 from air import H1, H2, H3, A, B, Div, Img, Link, P, SafeStr, Script
 from examples.html_sample import HTML_SAMPLE
-
-
-def render_html_pretty(html: str, *, theme: str = "dracula") -> None:
-    """Pretty-print and render HTML with syntax highlighting."""
-    syntax = Syntax(
-        html,
-        "html",
-        line_numbers=True,
-        word_wrap=True,
-    )
-    panel = Panel(
-        Padding(syntax, (0, 2)),
-        box=box.HEAVY,
-        title="Air → HTML",
-    )
-    console = Console()
-    console.print(panel, soft_wrap=False)
-
 
 if __name__ == "__main__":
     link = Link(
@@ -84,7 +62,7 @@ if __name__ == "__main__":
     # Full tag representation
     print(div.full_repr())
     # Render the generated HTML nicely in the terminal
-    render_html_pretty(div.pretty_render())
+    div.pretty_print()
 
     # Extra
     print(repr(HTML_SAMPLE.from_dict(HTML_SAMPLE.to_dict())))

--- a/src/air/tags/models/base.py
+++ b/src/air/tags/models/base.py
@@ -9,7 +9,7 @@ from functools import cached_property
 from types import MappingProxyType
 from typing import Any, ClassVar, Final, Self, TypedDict
 
-from ..utils import SafeStr, clean_html_attr_key, format_html
+from ..utils import SafeStr, clean_html_attr_key, pretty_format_html, pretty_print_html
 
 type AttributesType = str | int | float | bool
 
@@ -91,9 +91,19 @@ class BaseTag:
     def render(self) -> str:
         return self._render()
 
-    def pretty_render(self) -> str:
+    def pretty_render(
+        self,
+        *,
+        with_body: bool = False,
+        with_head: bool = False,
+        with_doctype: bool = False,
+    ) -> str:
         """Pretty-print without escaping."""
-        return format_html(self._render())
+        return pretty_format_html(self._render(), with_body=with_body, with_head=with_head, with_doctype=with_doctype)
+
+    def pretty_print(self) -> None:
+        """Pretty-print and render HTML with syntax highlighting."""
+        pretty_print_html(self.pretty_render())
 
     def _render(self) -> str:
         return self._render_paired()

--- a/src/air/tags/models/special.py
+++ b/src/air/tags/models/special.py
@@ -2,7 +2,7 @@
 
 from typing import Any, Literal, override
 
-from ..utils import locals_cleanup
+from ..utils import HTML_DOCTYPE, locals_cleanup
 from .base import AttributesType, BaseTag
 
 
@@ -11,7 +11,18 @@ class Html(BaseTag):
 
     @override
     def _render(self) -> str:
-        return f"<!doctype html>{self._render_paired()}"
+        return f"{HTML_DOCTYPE}{self._render_paired()}"
+
+    @override
+    def pretty_render(
+        self,
+        *,
+        with_body: bool = False,
+        with_head: bool = False,
+        with_doctype: bool = False,
+    ) -> str:
+        """Pretty-print without escaping."""
+        return super().pretty_render(with_doctype=True)
 
 
 class Transparent(BaseTag):

--- a/tests/test_html_utils.py
+++ b/tests/test_html_utils.py
@@ -1,0 +1,162 @@
+# tests/test_html_utils.py
+from __future__ import annotations
+
+import builtins
+from collections.abc import Callable
+
+import pytest
+
+# Adjust this import path if needed for your project layout.
+from air.tags.utils import (
+    EXTRA_FEATURE_PRETTY_ERROR_MESSAGE,
+    HTML_DOCTYPE,
+    format_html,
+    pretty_format_html,
+)
+
+# -----------------------
+# Helpers for expectations
+# -----------------------
+
+
+def _expected_format_html_fragment(*, pretty: bool, with_doctype: bool) -> str:
+    base: str = "<p>Hi</p>\n" if pretty else "<p>Hi</p>"
+    return (HTML_DOCTYPE + "\n" + base) if with_doctype else base
+
+
+def _expected_format_html_document(*, with_head: bool, pretty: bool, with_doctype: bool) -> str:
+    if not pretty:
+        base: str = (
+            "<html><head></head><body><p>Hi</p></body></html>" if with_head else "<html><body><p>Hi</p></body></html>"
+        )
+    else:
+        base = (
+            "<html>\n  <head></head>\n  <body>\n    <p>Hi</p>\n  </body>\n</html>\n"
+            if with_head
+            else "<html>\n  <body>\n    <p>Hi</p>\n  </body>\n</html>\n"
+        )
+    return (HTML_DOCTYPE + "\n" + base) if with_doctype else base
+
+
+def _expected_pretty_fragment_unescaped(*, with_doctype: bool) -> str:
+    base: str = "<div data-x=\"A & B and 'quote'\">C < D & E</div>\n"
+    return (HTML_DOCTYPE + "\n" + base) if with_doctype else base
+
+
+def _expected_pretty_document_unescaped(*, with_head: bool, with_doctype: bool) -> str:
+    inner: str = "    <div data-x=\"A & B and 'quote'\">C < D & E</div>\n"
+    if with_head:
+        base: str = f"<html>\n  <head></head>\n  <body>\n{inner}  </body>\n</html>\n"
+    else:
+        base = f"<html>\n  <body>\n{inner}  </body>\n</html>\n"
+    return (HTML_DOCTYPE + "\n" + base) if with_doctype else base
+
+
+# -----------------------
+# format_html: all combos
+# -----------------------
+
+
+@pytest.mark.parametrize(
+    "with_body,with_head,pretty,with_doctype",
+    [(wb, wh, pr, wd) for wb in (False, True) for wh in (False, True) for pr in (False, True) for wd in (False, True)],
+    ids=lambda v: ("T" if v else "F"),
+)
+def test_format_html_all_parameter_combinations(
+    *, with_body: bool, with_head: bool, pretty: bool, with_doctype: bool
+) -> None:
+    src: str = "<p>Hi</p>"
+
+    if not with_body:
+        expected: str = _expected_format_html_fragment(pretty=pretty, with_doctype=with_doctype)
+    else:
+        expected = _expected_format_html_document(with_head=with_head, pretty=pretty, with_doctype=with_doctype)
+
+    result: str = format_html(
+        src,
+        with_body=with_body,
+        with_head=with_head,
+        with_doctype=with_doctype,
+        pretty=pretty,
+    )
+    assert result == expected
+
+
+# -----------------------------------------
+# pretty_format_html: all 8 flag combos
+# (always uses pretty=True under the hood)
+# -----------------------------------------
+
+
+@pytest.mark.parametrize(
+    "with_body,with_head,with_doctype",
+    [(wb, wh, wd) for wb in (False, True) for wh in (False, True) for wd in (False, True)],
+    ids=lambda v: ("T" if v else "F"),
+)
+def test_pretty_format_html_all_parameter_combinations(*, with_body: bool, with_head: bool, with_doctype: bool) -> None:
+    # Include entities that will be unescaped by pretty_format_html.
+    src: str = '<div data-x="A &amp; B and &#x27;quote&#x27;">C &lt; D &amp; E</div>'
+
+    if not with_body:
+        expected: str = _expected_pretty_fragment_unescaped(with_doctype=with_doctype)
+    else:
+        expected = _expected_pretty_document_unescaped(with_head=with_head, with_doctype=with_doctype)
+
+    result: str = pretty_format_html(src, with_body=with_body, with_head=with_head, with_doctype=with_doctype)
+    assert result == expected
+
+
+# -----------------------------
+# Edge case: empty input raises
+# -----------------------------
+
+
+def test_format_html_empty_raises_parser_error() -> None:
+    from lxml.etree import ParserError
+
+    with pytest.raises(ParserError) as exc:
+        _ = format_html("")  # no defaults passed
+    assert exc.type.__name__ == "ParserError"
+
+
+def test_pretty_format_html_empty_raises_parser_error() -> None:
+    from lxml.etree import ParserError
+
+    with pytest.raises(ParserError) as exc:
+        _ = pretty_format_html("")  # no defaults passed
+    assert exc.type.__name__ == "ParserError"
+
+
+# ------------------------------------------
+# Edge case: missing lxml -> helpful message
+# ------------------------------------------
+
+
+def test_format_html_missing_lxml_message(monkeypatch: pytest.MonkeyPatch) -> None:
+    real_import: Callable[..., object] = builtins.__import__
+
+    def fake_import(name: str, *args: object, **kwargs: object) -> object:
+        if name == "lxml" or name.startswith("lxml."):
+            msg = "fake-missing-lxml"
+            raise ModuleNotFoundError(msg)
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", fake_import)
+    with pytest.raises(ModuleNotFoundError) as exc:
+        _ = format_html("<p>Hi</p>")  # no defaults passed
+    assert str(exc.value) == EXTRA_FEATURE_PRETTY_ERROR_MESSAGE
+
+
+def test_pretty_format_html_missing_lxml_message(monkeypatch: pytest.MonkeyPatch) -> None:
+    real_import: Callable[..., object] = builtins.__import__
+
+    def fake_import(name: str, *args: object, **kwargs: object) -> object:
+        if name == "lxml" or name.startswith("lxml."):
+            msg = "fake-missing-lxml"
+            raise ModuleNotFoundError(msg)
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", fake_import)
+    with pytest.raises(ModuleNotFoundError) as exc:
+        _ = pretty_format_html("<p>Hi</p>")  # no defaults passed
+    assert str(exc.value) == EXTRA_FEATURE_PRETTY_ERROR_MESSAGE

--- a/tests/test_tags_utils.py
+++ b/tests/test_tags_utils.py
@@ -4,7 +4,7 @@ These tests focus on `locals_cleanup` which filters a mapping of local
 arguments down to only those allowed for a given tag object.
 """
 
-from air.tags.utils import format_html, locals_cleanup
+from air.tags.utils import locals_cleanup
 
 
 def test_locals_cleanup_selects_allowed_attrs() -> None:
@@ -61,11 +61,3 @@ def test_locals_cleanup_defaults_for_unknown_class() -> None:
 
     # Only the default attribute keys are allowed for unknown classes
     assert result == {"class_": "c", "for_": "x", "style": "s"}
-
-
-def test_format_html() -> None:
-    escaped_html = (
-        "&lt;!doctype html&gt;&lt;html&gt;&lt;body&gt;&lt;h1&gt;Hello, world&lt;/h1&gt;&lt;/body&gt;&lt;/html&gt;"
-    )
-    html = "<!doctype html><html><body><h1>Hello, world</h1></body></html>"
-    assert html in format_html(escaped_html)


### PR DESCRIPTION
Closes: #475 

- Added exhaustive parameterized tests for `format_html` and `pretty_format_html` covering all combinations of options.
- Introduced edge case tests for empty inputs and missing `lxml` library handling with appropriate error messages.
- Refined `HTML_DOCTYPE` and error message constants for reuse and clarity across modules.
- Eliminated unused tests from `test_tags_utils.py` and integrated updated rendering logic into test cases.
This pull request refactors and enhances the HTML pretty-printing and formatting utilities in the Air Tag system. It introduces new functions for pretty-printing HTML with syntax highlighting, improves parameterization for formatting, and ensures better error handling when required dependencies are missing. The changes also update usage throughout the codebase and add comprehensive tests for these utilities.

**HTML pretty-printing and formatting improvements:**
* Added new functions `pretty_format_html` and `pretty_print_html` in `src/air/tags/utils.py`, allowing for more flexible pretty-printing of HTML with options for including body, head, and doctype, and integrated syntax highlighting using Rich. Also introduced a standardized error message for missing dependencies. [[1]](diffhunk://#diff-f2079f9aa1dd8d0ce2760ffd2bd3c15bdb84ff0892b16f8f154ca3ea08e4a331L4-R9) [[2]](diffhunk://#diff-f2079f9aa1dd8d0ce2760ffd2bd3c15bdb84ff0892b16f8f154ca3ea08e4a331L24-R97)
* Refactored `BaseTag` and `Html` classes to use the new pretty-printing utilities, providing more options for rendering and printing HTML in a readable format. [[1]](diffhunk://#diff-0de0eb99c9c8181ae6a7fd339542b6aaf46c643ef916083fe9beba79dc61fa33L94-R106) [[2]](diffhunk://#diff-5594096241bb45f489f9a2ed8c733e2e7d24c71038b05bf6349352bf60afbdb4L14-R25)

**Code cleanup and usage updates:**
* Removed the old `render_html_pretty` function from `examples/tags_render.py` and updated its usage to leverage the new `pretty_print` method. [[1]](diffhunk://#diff-3f34caa0ab58d24a4b5c96712aecb364d418916d69b28c7730bb0351ac69183aL15-L41) [[2]](diffhunk://#diff-3f34caa0ab58d24a4b5c96712aecb364d418916d69b28c7730bb0351ac69183aL87-R65)
* Updated imports and removed unused formatting functions from various files to align with the new utilities. [[1]](diffhunk://#diff-0de0eb99c9c8181ae6a7fd339542b6aaf46c643ef916083fe9beba79dc61fa33L12-R12) [[2]](diffhunk://#diff-5594096241bb45f489f9a2ed8c733e2e7d24c71038b05bf6349352bf60afbdb4L5-R5) [[3]](diffhunk://#diff-52d2d28e2484cc9c8b3cee6194ce9ac4a0fe0f6c2faec57828356464f6a0fda0L7-R7)

**Testing enhancements:**
* Added a new test suite `tests/test_html_utils.py` covering all parameter combinations for `format_html` and `pretty_format_html`, edge cases for empty input, and error messaging for missing dependencies.
* Removed outdated tests for the old formatting function from `tests/test_tags_utils.py`.
# Issue(s)

<!-- A link to an issue(s) on GitHub. If there isn't an issue(s), remove this section. -->
<!-- Note: Oversized pull requests will be requested to be broken up by the maintainers. -->

## Description

<!-- A summary of the changes made. -->
<!-- Add any links to other issues or secondary material. --> 

## Pull request type
<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [ ] New feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## Pull request tasks

The following have been completed for this task:

- [ ] Code changes
- [ ] Documentation changes for new or changed features
- [ ] Alterations of behavior come with a working implementation in the `examples` folder
- [ ] Tests on new or altered behaviors

## Demo or screenshot

<!-- If possible, link to a demo or screenshot of your change. -->
<!-- If not possible, remove this section. -->

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [ ] I have run `just test` and `just qa`, ensuring my code changes passes all existing tests
- [ ] I have performed a self-review of my own code
- [ ] I have ensured that there are tests to cover my changes

## Other information

<!-- If possible, link to a demo or screenshot of your change -->