### PR TITLE
Add lifespan db func to air.ext.sql

### DIFF
--- a/docs/api/ext/sql.md
+++ b/docs/api/ext/sql.md
@@ -1,12 +1,36 @@
 # ext.sql
 
+This module includes utility functions for using SQL with AIR.
+
+Introduces two environment variables
+
+- DEBUG
+- DATABASE_URL
+
+Requires additional dependencies installable in `air[sql]`, which can be installed with `uv add "air[sql]"`:
+
+- SQLModel
+- greenlet
+
+!!! warning
+
+    Persistent database connections require a lifespan object, otherwise you may receive timeout exceptions when the server is idle for even brief periods. To prevent this from happening, when using SQL connections in air views we strong recommend using the `air.ext.sql.async_db_lifespan` lifespan function.
+
+    ```python
+    import air
+
+    app = air.Air(lifespan=air.ext.sql.async_db_lifespan)
+    ```
+
+
 
 ::: air.ext.sql
     options:
       group_by_category: false
       members:
+        - DATABASE_URL      
         - DEBUG
-        - DATABASE_URL
+        - async_db_lifespan
         - create_sync_engine
         - create_async_engine
         - create_async_session

--- a/docs/learn/sql.md
+++ b/docs/learn/sql.md
@@ -17,16 +17,7 @@ To ensure the database remains connected to Air, we configure a `lifespan` funct
 So when instantiating your project's root 'app':
 
 ```python
-from contextlib import asynccontextmanager
 import air
 
-@asynccontextmanager
-async def lifespan(app: air.Air):
-    async_engine = air.ext.sql.create_async_engine()
-    async with async_engine.begin() as conn:
-        await conn.run_sync(lambda _: None)    
-    yield
-    await async_engine.dispose()
-
-app = air.Air(lifespan=lifespan)
+app = air.Air(lifespan=air.ext.sql.async_db_lifespan)
 ```

--- a/tests/ext/test_sql.py
+++ b/tests/ext/test_sql.py
@@ -3,6 +3,7 @@ from sqlalchemy import Engine
 from sqlalchemy.ext.asyncio import AsyncEngine, async_sessionmaker
 from sqlmodel.ext.asyncio.session import AsyncSession
 
+from air.applications import Air
 from air.ext import sql
 
 
@@ -99,3 +100,15 @@ async def test_get_object_or_404():
             await sql.get_object_or_404(session, TestUser, TestUser.id == 1, TestUser.name == "Wrong Name")
 
         assert exc_info.value.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_async_db_lifespan():
+    """Test the async_db_lifespan context manager."""
+    app = Air()
+
+    # Test that the lifespan runs without error
+    async with sql.async_db_lifespan(app):
+        # Inside the lifespan context, we should be able to proceed normally
+        pass
+    # The lifespan should complete successfully


### PR DESCRIPTION
# Issue(s)

#472 

## Description

Adds `async_db_lifespan` to the `air.ext.sql` module. This means we get to stop copy/pasting lifespan functions from one project to another.

## Pull request type
<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [x] New feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## Pull request tasks

The following have been completed for this task:

- [x] Code changes
- [x] Documentation changes for new or changed features
- [ ] Alterations of behavior come with a working implementation in the `examples` folder
- [x] Tests on new or altered behaviors

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] I have run `just test` and `just qa`, ensuring my code changes passes all existing tests
- [x] I have performed a self-review of my own code
- [x] I have ensured that there are tests to cover my changes
