### PR TITLE
FEAT: Make the default status_code of air.RedirectResponse be 303

### DIFF
--- a/src/air/responses.py
+++ b/src/air/responses.py
@@ -1,13 +1,16 @@
 """Air uses custom response classes to improve the developer experience."""
 
+from collections.abc import Mapping
 from typing import override
 
+from starlette.background import BackgroundTask
+from starlette.datastructures import URL
 from starlette.responses import (
     FileResponse as FileResponse,
     HTMLResponse as HTMLResponse,
     JSONResponse as JSONResponse,
     PlainTextResponse as PlainTextResponse,
-    RedirectResponse as RedirectResponse,
+    RedirectResponse as StarletteRedirectResponse,
     Response as Response,
     StreamingResponse as StreamingResponse,
 )
@@ -92,3 +95,14 @@ class SSEResponse(StreamingResponse):
             await send({"type": "http.response.body", "body": chunk, "more_body": True})
 
         await send({"type": "http.response.body", "body": b"", "more_body": False})
+
+
+class RedirectResponse(StarletteRedirectResponse):
+    def __init__(
+        self,
+        url: str | URL,
+        status_code: int = 303,
+        headers: Mapping[str, str] | None = None,
+        background: BackgroundTask | None = None,
+    ) -> None:
+        super().__init__(url=url, status_code=status_code, headers=headers, background=background)

--- a/tests/ext/test_auth.py
+++ b/tests/ext/test_auth.py
@@ -78,6 +78,6 @@ def test_github_callback_route() -> None:
 
         response = client.get("/account/github/callback")
 
-        assert response.history[0].status_code == 307
+        assert response.history[0].status_code == 303
         assert response.status_code == 200
         assert "Hello" in response.text

--- a/tests/test_responses.py
+++ b/tests/test_responses.py
@@ -274,6 +274,7 @@ def test_SSEResponse_bytes_content() -> None:
     assert response.headers["content-type"] == "text/event-stream; charset=utf-8"
     assert response.text == "already encoded"
 
+
 def test_RedirectResponse() -> None:
     """Test the RedirectResponse class."""
     app = air.Air()

--- a/tests/test_responses.py
+++ b/tests/test_responses.py
@@ -273,3 +273,24 @@ def test_SSEResponse_bytes_content() -> None:
     assert response.status_code == 200
     assert response.headers["content-type"] == "text/event-stream; charset=utf-8"
     assert response.text == "already encoded"
+
+def test_RedirectResponse() -> None:
+    """Test the RedirectResponse class."""
+    app = air.Air()
+
+    @app.get("/test2")
+    async def another_test_endpoint():
+        return air.AirResponse()
+
+    @app.get("/test")
+    async def test_endpoint():
+        return air.RedirectResponse("/test2")
+
+    client = TestClient(app)
+    response = client.get("/test", follow_redirects=False)
+    assert response.status_code == 303
+
+    # check if redirect works
+    response = client.get("/test", follow_redirects=True)
+    assert response.status_code == 200
+    assert "/test2" in response.url.path


### PR DESCRIPTION
# Issue(s)

Close #356 

## Description

makes the Air default for ResponseRedirect be 303, which turns it into a GET

## Pull request type

Please check the type of change your PR introduces:

- [ ] Bugfix
- [x] New feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## Pull request tasks

The following have been completed for this task:

- [x] Code changes
- [ ] Documentation changes for new or changed features
- [ ] Alterations of behavior come with a working implementation in the `examples` folder
- [x] Tests on new or altered behaviors


## Checklist

- [x] I have run `just test` and `just qa`, ensuring my code changes passes all existing tests
- [x] I have performed a self-review of my own code
- [x] I have ensured that there are tests to cover my changes