### PR TITLE
Provide option to set GH callback URI

### DIFF
--- a/docs/learn/quickstart.md
+++ b/docs/learn/quickstart.md
@@ -131,6 +131,22 @@ def air_is_grounded(): # (2)!
 1. `app.page` used over functions named `index` are converted to the `/` route.
 2. `app.page` used over functions are converted to a route based on their name, with underscores converted to dashes. 
 
+## Using Jinja with Air Tags
+
+TODO
+
+## JavaScript Files and Inline Scripts
+
+Here's how to call external JavaScript files or add inline scripts:
+
+
+```python
+import 
+
+```
+
+
+
 ## Want to learn more?
 
 Check out these documentation sections:


### PR DESCRIPTION
## Description

Hypercorn through PaaS vendors doesn't handle HTTP => HTTPS elegantly, or perhaps doesn't specify how to manage it internally. In either case, for the GH OAuth client we are allowing for the setting of the callback and domain.

This should allow use of OAuth with Hypercorn on PaaS

## Pull request type
<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] New feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## Pull request tasks

The following have been completed for this task:

- [x] Code changes
- [x] Documentation changes for new or changed features
- [ ] Alterations of behavior come with a working implementation in the `examples` folder
- [ ] Tests on new or altered behaviors


## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] I have run `just test` and `just qa`, ensuring my code changes passes all existing tests
- [x] I have performed a self-review of my own code
- [x] I have ensured that there are tests to cover my changes
