### PR TITLE
Add asyncpg extension

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 # region ----> project <----
 [project]
 name = "air"
-version = "0.33.0"
+version = "0.33.1"
 description = "The new Python web framework by the authors of Two Scoops of Django. Built with FastAPI, Starlette, and Pydantic."
 authors = [
     { name = "Audrey M. Roy Greenfeld", email = "audrey@feldroy.com" },

--- a/src/air/ext/__init__.py
+++ b/src/air/ext/__init__.py
@@ -4,6 +4,25 @@ from typing import TYPE_CHECKING, NoReturn
 if TYPE_CHECKING:
     GitHubOAuthRouterFactory: Callable
 
+
+try:
+    from . import asyncpg as asyncpg
+except ImportError:  # pragma: no cover
+    msg = "air.ext.asyncpg requires installing the asyncpg package."
+
+    class NotImportable:
+        def __getattribute__(self, name: str) -> NoReturn:
+            raise RuntimeError(msg)
+
+        def __str__(self) -> str:
+            return msg
+
+        def __repr__(self) -> str:
+            return msg
+
+    auth = NotImportable()  # ty:ignore[invalid-assignment]    
+
+
 try:
     from . import auth as auth
 except ImportError:  # pragma: no cover

--- a/src/air/ext/asyncpg.py
+++ b/src/air/ext/asyncpg.py
@@ -1,0 +1,39 @@
+from typing import AsyncIterator
+import asyncpg
+from ..applications import Air
+from contextlib import asynccontextmanager
+from typing import Callable
+from os import getenv
+
+DATABASE_URL = getenv('DATABASE_URL')
+
+
+def make_lifespan(dsn: str, *, min_size: int = 1, max_size: int = 10) -> Callable:
+    @asynccontextmanager
+    async def lifespan(app: Air) -> AsyncIterator[None]:
+        app.state.pool = await asyncpg.create_pool(
+            dsn=dsn,
+            min_size=min_size,
+            max_size=max_size,
+        )
+        try:
+            yield
+        finally:
+            await app.state.pool.close()
+
+    return lifespan
+
+
+
+@asynccontextmanager
+async def connect(database_url: str | None = DATABASE_URL):
+    """Usage:
+    
+    async with connect() as conn:
+        rows = await conn.fetch(stmt, *args)    
+    """
+    try:
+        conn = await asyncpg.connect(DATABASE_URL)
+        yield conn
+    finally:
+        await conn.close() 

--- a/uv.lock
+++ b/uv.lock
@@ -23,7 +23,7 @@ wheels = [
 
 [[package]]
 name = "air"
-version = "0.33.0"
+version = "0.33.1"
 source = { editable = "." }
 dependencies = [
     { name = "fastapi" },


### PR DESCRIPTION
## Description

This PR adds a couple of utility functions for running `asyncpg` outside of ORMs like SQLAlchemy and SQLModel.

## Pull request type
<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [x] New feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## Pull request tasks

The following have been completed for this task:

- [x] Code changes
- [ ] Documentation changes for new or changed features
- [ ] Alterations of behavior come with a working implementation in the `examples` folder
- [ ] Tests on new or altered behaviors

## Demo or screenshot

```python
import air

database_url = "postgresql://drg@localhost:5432/playground"

lifespan = air.ext.asyncpg.make_lifespan(database_url)

app = air.Air(lifespan=lifespan)

@app.page
async def index():
    async with air.ext.asynpg.connect(database_url) as conn:
        users = conn.fetch("SELECT * FROM users;")
    return air.UL(
        *[air.Li(u['username'] for u in users)]
    )
```


## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [ ] I have run `just test` and `just qa`, ensuring my code changes passes all existing tests
- [ ] I have performed a self-review of my own code
- [ ] I have ensured that there are tests to cover my changes

## Other information

TODO