### PR TITLE
Fix link to air tags

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -70,7 +70,7 @@ async def index():
 
 !!! note
 
-    This example uses [Air Tags](/air/ref/tags), which are Python classes that render as HTML. Air Tags are typed and documented, designed to work well with any code completion tool.
+    This example uses [Air Tags](/air/api/tags/), which are Python classes that render as HTML. Air Tags are typed and documented, designed to work well with any code completion tool.
 
 ## Combining FastAPI and Air
 


### PR DESCRIPTION
# Issue(s)

#565 

## Description

Fixes a borked doclink in the root of the Air Docs

## Pull request type
<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [ ] New feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [x] Documentation content changes
- [ ] Other (please describe):

## Pull request tasks

The following have been completed for this task:

- [ ] Code changes
- [x] Documentation changes for new or changed features
- [ ] Alterations of behavior come with a working implementation in the `examples` folder
- [ ] Tests on new or altered behaviors

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] I have run `just test` and `just qa`, ensuring my code changes passes all existing tests
- [x] I have performed a self-review of my own code
- [x] I have ensured that there are tests to cover my changes
