### PR TITLE
DOCS: book example uses the wrong library #576

### DIFF
--- a/docs/book/05-building-blog-application.md
+++ b/docs/book/05-building-blog-application.md
@@ -117,10 +117,10 @@ git commit -m "Add article files: hello-world.md, about-me.md, markdown-features
 
 ## Reading Articles into Our Application
 
-To read the articles from the `articles` directory, we'll use the `pathlib` and `python-frontmatter` libraries. First, install the frontmatter library:
+To read the articles from the `articles` directory, we'll use the `pathlib` and `frontmatter` libraries. First, install the frontmatter library:
 
 ```bash
-uv add python-frontmatter
+uv add frontmatter
 ```
 
 Now, let's modify our `main.py` file to read the articles and display them on the homepage:


### PR DESCRIPTION
# Issue(s)

[576](https://github.com/feldroy/air/issues/576)

## Description
updated the docs to use the correct library required by example (`frontmatter` instead of `python-frontmatter`).

## Pull request type
Please check the type of change your PR introduces:

- [ ] Bugfix
- [ ] New feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [X] Documentation content changes
- [ ] Other (please describe):

## Pull request tasks

The following have been completed for this task:

- [ ] Code changes
- [X] Documentation changes for new or changed features
- [ ] Alterations of behavior come with a working implementation in the `examples` folder
- [ ] Tests on new or altered behaviors

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [X] I have run `just test` and `just qa`, ensuring my code changes passes all existing tests
- [X] I have performed a self-review of my own code
- [ ] I have ensured that there are tests to cover my changes
