### PR TITLE
Fix a bug where basedpyright and pyright as well as Zed editor could not parse our pyproject.toml file!

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -191,55 +191,11 @@ conflicts = [
 # In mono-repo (meaning: multiple projects in one repo) or local dev, this guarantees
 # uv uses your checked-out code.
 air = { workspace = true }
-
-# -------- uv build backend (fast and strict) --------
-# ======================================================================
-# Why this build-backend section exists (the big picture for newcomers)
-#
-# Short version:
-# For a library, installing the library itself into the virtual environment
-# (not just its dependencies) is how modern Python packaging is meant to work.
-# Many features only “exist” after install because they’re defined by packaging
-# standards, not by simply having files on disk.
-#
-# Official Python basis:
-# • PEP 517/518 build systems: Projects declare a build backend in pyproject.toml.
-#   Front-ends (meaning: installers like pip/uv) build+install through that backend.
-#   That produces an installed distribution,
-#   with metadata (meaning: version, entry points, requirements).
-# • PEP 660 editable installs: In development, you install *editable* so code
-#   changes take effect without reinstalling, still producing a proper installed
-#   distribution with .dist-info.
-# • Entry points & console scripts: Commands and plugin hooks are created at
-#   *install time* from entry points. Without install, the commands/hooks do not exist.
-# • Distribution metadata: Tools read version and entry points via importlib.metadata
-#   from the installed .dist-info. No install → nothing to read.
-# • src/ layout: With “src/”, tests and tools should import the *installed* package
-#   (editable), not in-tree files. This matches how users import from PyPI.
-#
-# uv’s behavior:
-# • Package vs “virtual” project: Packages are installed into the venv (editable by
-#   default) and therefore need a build backend. “Virtual” projects only install deps.
-# • Auto-sync: `uv run` checks the lockfile/env before every run and, for packages,
-#   ensures your library is installed so commands run against the installed distribution.
-# • Editable by default: uv installs your project editable unless you pass --no-editable.
-# • No [build-system]? By default uv won’t install your project (only deps). You can
-#   force install with `tool.uv.package = true` (uv falls back to a legacy backend),
-#   but declaring a proper backend is the recommended path.
-#
-# Real-world effects you will notice:
-# 1) CLI commands appear only after install (via entry points), e.g. `air` on PATH.
-# 2) pytest/flake8 plugins are discovered only when installed (via entry points).
-# 3) `importlib.metadata.version("air")` works only for an installed distribution.
-# 4) src/ layout behaves correctly (imports mirror what end users get from PyPI).
-#
-# Takeaway:
-# For a Python 3.13+ library, an editable install is the spec-aligned (meaning:
-# follows the standard) workflow. It enables scripts, plugins, metadata, compiled
-# code, and correct src/ behavior. uv follows these standards and installs your
-# package by default so everything “just works”.
-# ======================================================================
+# -------- uv build backend --------
 # PEP 517/518: tells installers (pip/uv) how to build/install this project.
+# For Python libraries, an editable install is the standard:
+# it enables scripts, plugins, metadata, compiled code, and proper src/ behavior.
+# uv follows these standards and installs your package by default, ensuring everything “just works.”
 [build-system]
 # Ensure the chosen backend is present. A version range keeps CI reproducible
 # (meaning: stable over time) while allowing safe updates.
@@ -578,40 +534,52 @@ skip_covered = true
 ignore_errors = true
 precision = 0
 sort = "miss"
-exclude_lines = [
-    # --- standard/noise you already had ---
-    "pragma: no cover",
-    "pragma: lax no cover",
-    "^\\s*raise\\s+NotImplementedError",
-    "^\\s*if\\s+TYPE_CHECKING\\s*:",
-    "^\\s*if\\s+typing\\.TYPE_CHECKING\\s*:",
-    # --- imports anywhere ---
-    "^\\s*import\\s+",
-    "^\\s*from\\s+\\S+\\s+import\\s+",
-    # --- typing / decorators / protocols ---
-    "^\\s*from\\s+__future__\\s+import\\s+annotations\\s*$",
-    "@overload",
-    "@typing\\.overload",
-    "@abstractmethod",
-    "@deprecated",
-    "\\(Protocol\\):$",
-    # --- typing helpers and assertions ---
-    "^\\s*typing\\.cast\\(",
-    "^\\s*reveal_type\\(",
-    "^\\s*assert_never\\(",
-    "typing\\.assert_never",
-    "^\\s*[A-Za-z_][A-Za-z0-9_]*\\s*:\\s*[^=]+$", # pure variable annotations (no assignment)
 
-    # --- common non-runtime blocks / noise ---
-    "^if __name__ == ['\\\"]__main__['\\\"]:",
-    "^\\s*except\\s+ImportError\\s+as\\s+_import_error\\s*:",
-    "^\\s*pass$",
-    "^\\s*assert\\s+False\\b",
-    # --- ellipsis placeholders ---
-    "^\\s*\\.\\.\\.\\s*(#.*)?$", # line that is just "..."
-    "^\\s*return\\s+\\.\\.\\.\\s*(#.*)?$", # return ...
-    "^\\s*[A-Za-z_][A-Za-z0-9_]*\\s*:\\s*[^=]+=\\s*\\.\\.\\.\\s*$", # x: T = ...
-    "^\\s*(?:async\\s+)?def\\s+\\w+\\s*\\(.*\\)\\s*(?:->[^:]+)?\\s*:\\s*\\.\\.\\.$", # def func(...) -> Type: ...
+exclude_lines = [
+    # Pragmas explicitly telling Coverage to skip
+    'pragma: no cover', # skip lines marked not to cover
+    'pragma: lax no cover', # skip lines marked lax not to cover
+
+    # TYPE_CHECKING guards
+    '^\s*if\s+TYPE_CHECKING\s*:', # runtime-false typing gate
+    '^\s*if\s+typing\.TYPE_CHECKING\s*:', # runtime-false typing gate (qualified)
+
+    # Imports (declarations, not behavior)
+    '^\s*import\s+', # bare import lines
+    '^\s*from\s+\S+\s+import\s+', # from-import lines
+
+    # Typing/decorators/protocol markers
+    '^\s*from\s+__future__\s+import\s+annotations\s*$', # future annotations import
+    '@overload', # typing overload stub
+    '@typing\.overload', # typing overload stub (qualified)
+    '@abstractmethod', # abstract method decorator
+    '@deprecated', # deprecated decorator marker
+    '\(Protocol\):$', # Protocol base class line
+
+    # Typing helpers and asserts
+    '^\s*typing\.cast\(', # typing cast helper
+    '^\s*reveal_type\(', # static type reveal helper
+    '^\s*assert_never\(', # assert_never helper
+    'typing\.assert_never', # qualified assert_never
+    '^\s*[A-Za-z_][A-Za-z0-9_]*\s*:\s*[^=]+$', # pure annotation (no assignment)
+
+    # Main guards
+    "^if __name__ == '__main__':", # entrypoint guard (single quotes)
+    '^if __name__ == "__main__":', # entrypoint guard (double quotes)
+
+    # Intentional stub exceptions
+    '^\s*raise\s+NotImplementedError', # explicit unimplemented stub
+
+    # Common non-runtime noise
+    '^\s*except\s+ImportError\s+as\s+_import_error\s*:', # optional import shim branch
+    '^\s*pass$', # no-op pass
+    '^\s*assert\s+False\b', # hard stop assertion
+
+    # Ellipsis placeholders
+    '^\s*\.\.\.\s*(#.*)?$', # bare ellipsis
+    '^\s*return\s+\.\.\.\s*(#.*)?$', # return ellipsis
+    '^\s*[A-Za-z_][A-Za-z0-9_]*\s*:\s*[^=]+=\s*\.\.\.\s*$', # annotated ellipsis assignment
+    '^\s*(?:async\s+)?def\s+\w+\s*\(.*\)\s*(?:->[^:]+)?\s*:\s*\.\.\.$'  # function body ellipsis
 ]
 
 [tool.coverage.html]


### PR DESCRIPTION
> [!IMPORTANT]
> Fix a bug where basedpyright and pyright as well as Zed editor could not parse our pyproject.toml file! 

- Simplified and condensed build backend documentation for clarity.
- Streamlined `tool.coverage.report.exclude_lines` by grouping and reformatting patterns for readability and consistency.

This pull request updates the `pyproject.toml` file with improvements to documentation and configuration clarity, focusing on build backend explanation and coverage exclusion patterns. The changes streamline the build backend section and clarify coverage exclusion rules for maintainability and readability.

**Build Backend Documentation Improvements:**

* Replaced a lengthy, detailed explanation of the build backend with a concise summary, making it easier for newcomers to understand the project's use of PEP 517/518 and editable installs.

**Coverage Exclusion Pattern Clarifications:**

* Refactored the `exclude_lines` section for test coverage, grouping patterns by theme (pragmas, imports, typing, main guards, exceptions, and placeholders), simplifying comments, and improving consistency in regex formatting.