### PR TITLE
Add FastAPI API property to Air application

### DIFF
--- a/src/air/applications.py
+++ b/src/air/applications.py
@@ -46,6 +46,8 @@ class Air(FastAPI):
         lifespan: A `Lifespan` context manager handler. This replaces `startup` and
                 `shutdown` functions with a single context manager.
         path_separator: An optional path separator, default to "-". valid option available ["/", "-"]
+        fastapi_app: An optional FastAPI project assigned to the `api` property
+
     Example:
 
         import air
@@ -323,6 +325,18 @@ class Air(FastAPI):
             ),
         ] = None,
         path_separator: Annotated[Literal["/", "-"], Doc("An optional path separator.")] = "-",
+        fastapi_app: Annotated[
+            FastAPI | None,
+            Doc(
+                """
+                The app that serves out an API.
+
+                Set to `None` to disable it.
+
+                If no routes are attached to the app, it disables itself.
+                """
+            ),
+        ] = FastAPI,
         **extra: Annotated[
             Any,
             Doc(
@@ -363,6 +377,14 @@ class Air(FastAPI):
         )
 
         self.router.route_class = AirRoute
+        if fastapi_app is not None:
+            self.fastapi_app = fastapi_app()
+            self.mount("/api", self.fastapi_app)
+
+    @property
+    def api(self) -> FastAPI | None:
+        """Access the FastAPI application for API routes."""
+        return self.fastapi_app
 
     def page(self, func: FunctionType) -> FunctionType:
         """Decorator that creates a GET route using the function name as the path.

--- a/tests/test_applications.py
+++ b/tests/test_applications.py
@@ -182,3 +182,27 @@ def test_injection_of_default_exception_handlers() -> None:
     expected_handlers = {**DEFAULT_EXCEPTION_HANDLERS, **CUSTOM_EXCEPTION_HANDLERS}
     assert set(expected_handlers) <= set(app.exception_handlers)
     assert app.exception_handlers[405] is handler
+
+
+def test_api_namespace_in_air() -> None:
+    app = air.Air()
+
+    @app.page
+    def index() -> air.H1:
+        return air.H1("Hello, World!")
+
+    client = TestClient(app)
+    response = client.get("/")
+
+    assert response.status_code == 200
+    assert response.headers["content-type"] == "text/html; charset=utf-8"
+    assert response.text == "<h1>Hello, World!</h1>"
+
+    @app.api.get("/items")
+    def get_items():
+        return {"items": ["one", "two", "three"]}
+
+    client = TestClient(app)
+    response = client.get("/api/items")
+    assert response.status_code == 200
+    assert response.json() == {"items": ["one", "two", "three"]}


### PR DESCRIPTION
# Issue(s)

#575 

## Description

Introduces an optional FastAPI app mounted at '/api' via the new 'fastapi_app' parameter and 'api' property in the Air class. Adds tests to verify API route mounting and response behavior.

This will make it easier for project creators to combine Air and FastAPI, since they are already one project. The `api` property can be prevented.

Currently state, including lifespan, isn't shared. For reference, it is not easy for this feature to share state.

## Pull request type
<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [x] New feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## Pull request tasks

The following have been completed for this task:

- [c] Code changes
- [ ] Documentation changes for new or changed features
- [ ] Alterations of behavior come with a working implementation in the `examples` folder
- [x] Tests on new or altered behaviors

## Demo or screenshot

```python
import air

app = Air()

@app.page
def index() -> air.H1:
    return air.H1("Hello, World!")


@app.api.get("/items")
def get_items():
    return {"items": ["one", "two", "three"]}
```


## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [ ] I have run `just test` and `just qa`, ensuring my code changes passes all existing tests
- [ ] I have performed a self-review of my own code
- [ ] I have ensured that there are tests to cover my changes
