### PR TITLE
Update FastAPI dependency to >=0.119.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,8 +35,7 @@ classifiers = [
 ]
 
 dependencies = [
-    # fastapi==0.119.0: Core Pydantic V1 functionality isn't compatible with Python 3.14 or greater.
-    "fastapi==0.118.3",
+    "fastapi>=0.119.1",
     "itsdangerous>=2.2.0",
     "Jinja2>=3.1.6",
     "python-multipart>=0.0.20",


### PR DESCRIPTION
## Description

Changed FastAPI version requirement from 0.118.3 to >=0.119.1 in pyproject.toml to ensure compatibility with Python 3.14+ and to get us completely past v1 of pydantic.

## Pull request type
<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] **Bugfix**
- [ ] **New feature**
    - [ ] **Core Air** (Air Tags, Request/Response cycle, etc)
    - [ ] **Optional** (Authentication, CSRF, etc)
    - [ ] **Third-Party Integrated** (Cookbook documentation on using Air databases or a task manager, etc)
    - [ ] **Out-of-Scope** (Formal integration with databases, external task managers, or commercial services etc - won't be accepted, please create a separate project)
- [ ] **Refactoring** (no functional changes, no api changes)
- [ ] **Build related changes**
- [ ] **Documentation content changes**
- [x] **Other** (please describe): fastapi update

## Pull request tasks

The following have been completed for this task:

- [x] **Code changes**
- [ ] **Documentation changes for new or changed features**
-  x] **Alterations of behavior come with a working implementation in the `examples` folder**
- [x] **Tests on new or altered behaviors**

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] **I have run `just test` and `just qa`, ensuring my code changes passes all existing tests**
- [x] **I have performed a self-review of my own code**
- [x] **I have ensured that there are tests to cover my changes**
