### PR TITLE
Add navigation footer for next/previous page navigation

### DIFF
--- a/mkdocs.yaml
+++ b/mkdocs.yaml
@@ -91,6 +91,7 @@ theme:
     - navigation.instant
     - navigation.instant.prefetch
     - navigation.tracking
+    - navigation.footer
     - search.suggest
     - search.highlight
     - search.share


### PR DESCRIPTION
Enables next/previous page navigation in the docs by adding the navigation.footer feature to the Material theme.