### PR TITLE
Skip codecov upload step if token is unset

### DIFF
--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -89,6 +89,8 @@ jobs:
     name: Send Coverage to Codecov
     runs-on: ubuntu-latest
     timeout-minutes: 25
+    env:
+      CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
     steps:
       - uses: actions/checkout@v5
       - uses: taiki-e/install-action@just
@@ -96,8 +98,9 @@ jobs:
       - name: Generating an XML Coverage Report
         run: just coverage-xml
       - name: Upload Coverage Report to Codecov
+        if: env.CODECOV_TOKEN != ''
         uses: codecov/codecov-action@v5
         with:
           files: coverage.xml
           fail_ci_if_error: true
-          token: ${{ secrets.CODECOV_TOKEN }}
+          token: ${{ env.CODECOV_TOKEN }}


### PR DESCRIPTION
# Issue(s)

Upon syncing my forked repository, I noticed that the CI workflow is failing.

## Description

This PR ensures the Codecov upload step is skipped when no CODECOV_TOKEN is provided, preventing attempts to upload without a token and avoiding related workflow errors. Particularly in forked repos


## Pull request type
<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] **Bugfix**
- [ ] **New feature**
    - [ ] **Core Air** (Air Tags, Request/Response cycle, etc)
    - [ ] **Optional** (Authentication, CSRF, etc)
    - [ ] **Third-Party Integrated** (Cookbook documentation on using Air databases or a task manager, etc)
    - [ ] **Out-of-Scope** (Formal integration with databases, external task managers, or commercial services etc - won't be accepted, please create a separate project)
- [ ] **Refactoring** (no functional changes, no api changes)
- [x] **Build related changes**
- [ ] **Documentation content changes**
- [ ] **Other** (please describe):

## Pull request tasks

The following have been completed for this task:

- [ ] **Code changes**
- [ ] **Documentation changes for new or changed features**
- [ ] **Alterations of behavior come with a working implementation in the `examples` folder**
- [ ] **Tests on new or altered behaviors**

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [ ] **I have run `just test` and `just qa`, ensuring my code changes passes all existing tests**
- [x] **I have performed a self-review of my own code**
- [ ] **I have ensured that there are tests to cover my changes**

## Demo or screenshot

<img width="2018" height="1480" alt="image" src="https://github.com/user-attachments/assets/dea78db4-da87-4b37-bbe3-e961d66bae5e" />


## Other information

<!-- If there's anything else not covered above, provide it here -->
<!-- If there's nothing else, remove this section. -->