### PR TITLE
docs: removed one slash in the link preview, and added one slash in the link url (issue #613)

### DIFF
--- a/docs/about/help_air.md
+++ b/docs/about/help_air.md
@@ -8,7 +8,7 @@ We're happy to assist with both!
 
 ## Star **Air** in GitHub  ⭐️
 
-You can "star" Air in GitHub (clicking the star button at the top right): [/github.com/feldroy/air](https:/github.com/feldroy/air).
+You can "star" Air in GitHub (clicking the star button at the top right): [github.com/feldroy/air](https://github.com/feldroy/air).
 
 By adding a star, other users will be able to find it more easily and see that it has been already useful for others.
 
@@ -22,7 +22,7 @@ By doing it, you will receive notifications (in your email) whenever there's a n
 
 ## Participate in discussions
 
-Our primary location for chat is our [Discord chat server](https://discord.gg/znf8vPsz47).  
+Our primary location for chat is our [Discord chat server](https://discord.gg/znf8vPsz47).
 
 For non-code GitHub issues, we'll ask those to be moved to the Discord chat server.
 


### PR DESCRIPTION
…e link url

# Issue(s)

[issue #613](https://github.com/feldroy/air/issues/613)

## Description

The problem was an unfindable link because of a missing slash.

That is why I added a slash to the link for the link to redirect to the correct website link.

## Pull request type

- [ ] **Bugfix**
- [ ] **New feature**
    - [ ] **Core Air** (Air Tags, Request/Response cycle, etc)
    - [ ] **Optional** (Authentication, CSRF, etc)
    - [ ] **Third-Party Integrated** (Cookbook documentation on using Air databases or a task manager, etc)
    - [ ] **Out-of-Scope** (Formal integration with databases, external task managers, or commercial services etc - won't be accepted, please create a separate project)
- [ ] **Refactoring** (no functional changes, no api changes)
- [ ] **Build related changes**
- [x] **Documentation content changes**
- [ ] **Other** (please describe):

## Pull request tasks

- [ ] **Code changes**
- [x] **Documentation changes for new or changed features**
- [ ] **Alterations of behavior come with a working implementation in the `examples` folder**
- [ ] **Tests on new or altered behaviors**

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] **I have run `just test` and `just qa`, ensuring my code changes passes all existing tests**
- [x] **I have performed a self-review of my own code**
- [x] **I have ensured that there are tests to cover my changes**

## Demo or screenshot

<img width="992" height="176" alt="image" src="https://github.com/user-attachments/assets/5ae42616-05f9-4c32-9278-17b4f5813b1f" />