### PR TITLE
Proxy Request to AirRequest

### DIFF
--- a/docs/api/requests.md
+++ b/docs/api/requests.md
@@ -56,7 +56,7 @@ async def create_item(request: Request):
 ### Reading Form Data
 ```python
 import air
-from air.requests import AirRequest
+from air.requests import Request
 from air.responses import JSONResponse
 
 app = air.Air()
@@ -74,15 +74,13 @@ async def login(request: Request):
 
 ### Accessing the HTMX object
 
-This requires use of the `air.requests.AirRequest` object.
-
 ```python
 import air
 
 app = air.Air()
 
 @app.page
-def index(request: air.AirRequest):
+def index(request: air.Request):
     return air.layouts.mvpcss(
         air.H1(f'From HTMX?'),
         air.P(f"This request came from an HTMX element on a page: {request.htmx}")
@@ -93,6 +91,7 @@ def index(request: air.AirRequest):
 ::: air.requests
     options:
       group_by_category: false
-      members:
-        - AirRequest
-        - HtmxDetails      
+      members: 
+        - AirRequest        
+        - HtmxDetails             
+        - Request        

--- a/src/air/requests.py
+++ b/src/air/requests.py
@@ -6,7 +6,7 @@ from typing import Any, Final
 from urllib.parse import urlsplit, urlunsplit
 
 from starlette.datastructures import Headers as Headers
-from starlette.requests import Request as Request
+from starlette.requests import Request as _Request
 
 # HTMX Header names as constants
 HX_REQUEST: Final = "HX-Request"
@@ -151,7 +151,7 @@ class HtmxDetails:
         return None
 
 
-class AirRequest(Request):
+class AirRequest(_Request):
     """A wrapper around `starlette.requests.Request` that includes the `HtmxDetails` object.
 
     !!! note
@@ -162,3 +162,6 @@ class AirRequest(Request):
     @property
     def htmx(self) -> HtmxDetails:
         return HtmxDetails(headers=self.headers, url=self.url)
+
+
+Request = AirRequest


### PR DESCRIPTION
It is common for people to import Request directly from Air, FastAPI, or Starlette. This means people are missing the `HTMXDetails` feature of AirRequest. To mitigate this behavior we are proxying AirRequest to Request. While this kind of breaks a naming pattern, it is nice enough syntactic sugar to make it worthwhile.


## Pull request type
<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] **Bugfix**
- [ ] **New feature**
    - [x] **Core Air** (Air Tags, Request/Response cycle, etc)
    - [ ] **Optional** (Authentication, CSRF, etc)
    - [ ] **Third-Party Integrated** (Cookbook documentation on using Air databases or a task manager, etc)
    - [ ] **Out-of-Scope** (Formal integration with databases, external task managers, or commercial services etc - won't be accepted, please create a separate project)
- [ ] **Refactoring** (no functional changes, no api changes)
- [ ] **Build related changes**
- [ ] **Documentation content changes**
- [ ] **Other** (please describe):

## Pull request tasks

The following have been completed for this task:

- [x] **Code changes**
- [x] **Documentation changes for new or changed features**
- [x] **Alterations of behavior come with a working implementation in the `examples` folder**
- [x] **Tests on new or altered behaviors**

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] **I have run `just test` and `just qa`, ensuring my code changes passes all existing tests**
- [x] **I have performed a self-review of my own code**
- [x] **I have ensured that there are tests to cover my changes**
