### PR TITLE
Add SessionMiddleware example test

### DIFF
--- a/src/air/middleware.py
+++ b/src/air/middleware.py
@@ -18,11 +18,13 @@ class SessionMiddleware(StarletteSessionMiddleware):
 
     Example:
 
-        import air
         from time import time
+
+        import air
 
         app = air.Air()
         app.add_middleware(air.SessionMiddleware, secret_key="change-me")
+
 
         @app.page
         async def index(request: air.Request):
@@ -33,6 +35,7 @@ class SessionMiddleware(StarletteSessionMiddleware):
                 air.P("Refresh the page and the timestamp won't change"),
                 air.P(air.A("Reset the time stamp", href="/reset")),
             )
+
 
         @app.page
         async def reset(request: air.Request):

--- a/src_examples/middleware__SessionMiddleware__test.py
+++ b/src_examples/middleware__SessionMiddleware__test.py
@@ -1,0 +1,34 @@
+from fastapi.testclient import TestClient
+
+from .middleware__SessionMiddleware import app
+
+
+def test_session_persistence() -> None:
+    client = TestClient(app)
+
+    response = client.get("/")
+    assert response.status_code == 200
+    assert response.headers["content-type"] == "text/html; charset=utf-8"
+
+    first_timestamp = response.text
+    assert "first-visited" in response.text or "<h1>" in response.text
+
+    response = client.get("/")
+    assert response.status_code == 200
+    assert response.text == first_timestamp
+
+
+def test_session_reset() -> None:
+    client = TestClient(app)
+
+    response = client.get("/")
+    assert response.status_code == 200
+    first_timestamp = response.text
+
+    response = client.get("/reset")
+    assert response.status_code == 200
+
+    response = client.get("/")
+    assert response.status_code == 200
+    second_timestamp = response.text
+    assert first_timestamp != second_timestamp


### PR DESCRIPTION
Added a new test file demonstrating session persistence and reset behavior for SessionMiddleware.

## Pull request type
<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] **Bugfix**
- [ ] **New feature**
    - [ ] **Core Air** (Air Tags, Request/Response cycle, etc)
    - [ ] **Optional** (Authentication, CSRF, etc)
    - [ ] **Third-Party Integrated** (Cookbook documentation on using Air databases or a task manager, etc)
    - [ ] **Out-of-Scope** (Formal integration with databases, external task managers, or commercial services etc - won't be accepted, please create a separate project)
- [ ] **Refactoring** (no functional changes, no api changes)
- [ ] **Build related changes**
- [x] **Documentation content changes**
- [ ] **Other** (please describe):

## Pull request tasks

The following have been completed for this task:

- [ ] **Code changes**
- [x] **Documentation changes for new or changed features**
- [ ] **Alterations of behavior come with a working implementation in the `examples` folder**
- [ ] **Tests on new or altered behaviors**

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [ ] **I have run `just test` and `just qa`, ensuring my code changes passes all existing tests**
- [ ] **I have performed a self-review of my own code**
- [ ] **I have ensured that there are tests to cover my changes**
