### PR TITLE
docs(contributing): emphasise using the PR template when opening pull requests

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -94,6 +94,9 @@ git push -u origin your-new-branch-name
 ```bash
 gh pr create --fill --repo feldroy/air
 ```
+[!IMPORTANT]
+> When opening a pull request, make sure to fill out the **Pull Request Template** completely.  
+> This helps maintainers review your contribution quickly and keeps the process consistent.
 
 ---
 


### PR DESCRIPTION
# Summary

This PR adds a short, clear reminder in the **CONTRIBUTING.md** file to ensure contributors fill out the Pull Request template when opening PRs.  

The goal is to help maintainers reduce review overhead and keep submissions consistent.

# Issue(s)

None

## Pull request type
<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] **Bugfix**
- [ ] **New feature**
    - [ ] **Core Air** (Air Tags, Request/Response cycle, etc)
    - [ ] **Optional** (Authentication, CSRF, etc)
    - [ ] **Third-Party Integrated** (Cookbook documentation on using Air databases or a task manager, etc)
    - [ ] **Out-of-Scope** (Formal integration with databases, external task managers, or commercial services etc - won't be accepted, please create a separate project)
- [ ] **Refactoring** (no functional changes, no api changes)
- [ ] **Build related changes**
- [x] **Documentation content changes**
- [ ] **Other** (please describe):

## Pull request tasks

The following have been completed for this task:

- [ ] **Code changes**
- [x] **Documentation changes for new or changed features**
- [ ] **Alterations of behavior come with a working implementation in the `examples` folder**
- [ ] **Tests on new or altered behaviors**

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] **I have run `just test` and `just qa`, ensuring my code changes passes all existing tests**
- [x] **I have performed a self-review of my own code**
- [ ] **I have ensured that there are tests to cover my changes**