### PR TITLE
docs: add docstrings for base tags Table to Textarea

### DIFF
--- a/src/air/tags/models/stock.py
+++ b/src/air/tags/models/stock.py
@@ -2499,7 +2499,7 @@ class Template(BaseTag):
 
 class Textarea(BaseTag):
     """Defines a multiline input control (text area)
-    
+
     Args:
         children: Tags, strings, or other rendered content.
         autocapitalize: Determines whether inputted text is automatically capitalized.


### PR DESCRIPTION
Adding docstrings for the following base tags:
* Table
* Tbody
* Td
* Template
* Textarea

# Issue(s)
https://github.com/feldroy/air/issues/172

## Pull request type
Please check the type of change your PR introduces:

- [ ] **Bugfix**
- [ ] **New feature**
    - [ ] **Core Air** (Air Tags, Request/Response cycle, etc)
    - [ ] **Optional** (Authentication, CSRF, etc)
    - [ ] **Third-Party Integrated** (Cookbook documentation on using Air databases or a task manager, etc)
    - [ ] **Out-of-Scope** (Formal integration with databases, external task managers, or commercial services etc - won't be accepted, please create a separate project)
- [ ] **Refactoring** (no functional changes, no api changes)
- [ ] **Build related changes**
- [x] **Documentation content changes**
- [ ] **Other** (please describe):

## Pull request tasks

The following have been completed for this task:

- [ ] **Code changes**
- [ ] **Documentation changes for new or changed features**
- [ ] **Alterations of behavior come with a working implementation in the `examples` folder**
- [ ] **Tests on new or altered behaviors**

## Checklist

- [x] **I have run `just test` and `just qa`, ensuring my code changes passes all existing tests**
- [x] **I have performed a self-review of my own code**
- [ ] **I have ensured that there are tests to cover my changes**

## Demo or screenshot

## Other information
