### PR TITLE
Live reload for docs

### DIFF
--- a/justfile
+++ b/justfile
@@ -285,7 +285,7 @@ coverage-md: coverage-xml
 # Serve docs locally
 [group('docs')]
 doc:
-    just run -- mkdocs serve -a localhost:3000
+    just run -- mkdocs serve -a localhost:3000 --livereload
 
 # Build docs
 [group('docs')]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -118,6 +118,7 @@ test = [
     "full-match>=0.0.3",
 ]
 docs = [
+    "click==8.2.1", # Necessary to allow live reload to work
     "greenlet>=3.2.4",
     "mkdocs-material[imaging]>=9.6.17", # MkDocs theme
     "mkdocstrings[python]>=0.30.0", # generate API docs from docstrings automatically

--- a/uv.lock
+++ b/uv.lock
@@ -52,6 +52,7 @@ standard = [
 [package.dev-dependencies]
 dev = [
     { name = "aiosqlite" },
+    { name = "click" },
     { name = "codespell" },
     { name = "coverage" },
     { name = "diff-cover" },
@@ -91,6 +92,7 @@ devtools = [
     { name = "uvicorn" },
 ]
 docs = [
+    { name = "click" },
     { name = "greenlet" },
     { name = "mkdocs" },
     { name = "mkdocs-autorefs" },
@@ -153,6 +155,7 @@ provides-extras = ["standard", "pretty", "sqlmodel", "auth", "all"]
 [package.metadata.requires-dev]
 dev = [
     { name = "aiosqlite", specifier = ">=0.21.0" },
+    { name = "click", specifier = "==8.2.1" },
     { name = "codespell", specifier = ">=2.4.1" },
     { name = "coverage", extras = ["toml"], specifier = ">=7.8.2" },
     { name = "diff-cover", specifier = ">=9.6.0" },
@@ -192,6 +195,7 @@ devtools = [
     { name = "uvicorn", specifier = ">=0.34.0" },
 ]
 docs = [
+    { name = "click", specifier = "==8.2.1" },
     { name = "greenlet", specifier = ">=3.2.4" },
     { name = "mkdocs", specifier = ">=1.6.1" },
     { name = "mkdocs-autorefs", specifier = ">=1.4.2" },
@@ -487,14 +491,14 @@ wheels = [
 
 [[package]]
 name = "click"
-version = "8.3.0"
+version = "8.2.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "colorama", marker = "sys_platform == 'win32'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/46/61/de6cd827efad202d7057d93e0fed9294b96952e188f7384832791c7b2254/click-8.3.0.tar.gz", hash = "sha256:e7b8232224eba16f4ebe410c25ced9f7875cb5f3263ffc93cc3e8da705e229c4", size = 276943, upload-time = "2025-09-18T17:32:23.696Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/60/6c/8ca2efa64cf75a977a0d7fac081354553ebe483345c734fb6b6515d96bbc/click-8.2.1.tar.gz", hash = "sha256:27c491cc05d968d271d5a1db13e3b5a184636d9d930f148c50b038f0d0646202", size = 286342, upload-time = "2025-05-20T23:19:49.832Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/db/d3/9dcc0f5797f070ec8edf30fbadfb200e71d9db6b84d211e3b2085a7589a0/click-8.3.0-py3-none-any.whl", hash = "sha256:9b9f285302c6e3064f4330c05f05b81945b2a39544279343e6e7c5f27a9baddc", size = 107295, upload-time = "2025-09-18T17:32:22.42Z" },
+    { url = "https://files.pythonhosted.org/packages/85/32/10bb5764d90a8eee674e9dc6f4db6a0ab47c8c4d0d83c27f7c39ac415a4d/click-8.2.1-py3-none-any.whl", hash = "sha256:61a3265b914e850b85317d0b3109c7f8cd35a670f963866005d6ef1d5175a12b", size = 102215, upload-time = "2025-05-20T23:19:47.796Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Unlike material-for-mkdocs the core mkdocs library is unmaintained. One side effect of that is that live reload for docs isn't working. The material-for-mkdocs is building out a new project, zensical, which we will probably covert over to. In the meantime, here's a patch for getting the docs to live reload again.

# Issue(s)

#762

## Pull request type
<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] **Bugfix**
- [ ] **New feature**
    - [ ] **Core Air** (Air Tags, Request/Response cycle, etc)
    - [ ] **Optional** (Authentication, CSRF, etc)
    - [ ] **Third-Party Integrated** (Cookbook documentation on using Air databases or a task manager, etc)
    - [ ] **Out-of-Scope** (Formal integration with databases, external task managers, or commercial services etc - won't be accepted, please create a separate project)
- [ ] **Refactoring** (no functional changes, no api changes)
- [ ] **Build related changes**
- [x] **Documentation content changes**
- [ ] **Other** (please describe):

## Pull request tasks

The following have been completed for this task:

- [ ] **Code changes**
- [x] **Documentation changes for new or changed features**
- [ ] **Alterations of behavior come with a working implementation in the `examples` folder**
- [ ] **Tests on new or altered behaviors**

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] **I have run `just test` and `just qa`, ensuring my code changes passes all existing tests**
- [x] **I have performed a self-review of my own code**
- [x] **I have ensured that there are tests to cover my changes**
