### PR TITLE
Add support for 'async_' key in HTML attributes

### DIFF
--- a/src/air/tags/utils.py
+++ b/src/air/tags/utils.py
@@ -44,7 +44,7 @@ def clean_html_attr_key(key: str) -> str:
     """
     # If a "_"-suffixed proxy for "class", "for", or "id" is used,
     # convert it to its normal HTML equivalent.
-    key = {"class_": "class", "for_": "for", "id_": "id", "as_": "as", "async_":"async"}.get(key, key)
+    key = {"class_": "class", "for_": "for", "id_": "id", "as_": "as", "async_": "async"}.get(key, key)
     # Remove leading underscores and replace underscores with dashes
     return key.lstrip("_").replace("_", "-")
 


### PR DESCRIPTION
Add `async` argument to conversions dict so `async_` converts to `async` similar to how `class_` works.

This is helpful because in `airclerk` there are Script tags defined like `async_=True`, but those get rendered to html like `async-` instead of `async`

```
>>> air.Script('abcd', async_=True).render()
'<script async->abcd</script>'
```


