### PR TITLE
Added a link to "What makes documentation good?" to the documentation section in `CONTRIBUTING.md`

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -166,6 +166,7 @@ require complete docstrings. This will help us maintain a high-quality documenta
   public functions, classes, and methods.
     - Use the `Args:` and `Return:` (or `Yields:` for generators) directives to document parameters and return values
     - Use the `Example:` directive to document how to use the function, class, or method being documented.
+- [What makes documentation good?](https://github.com/openai/openai-cookbook/blob/main/articles/what_makes_documentation_good.md)
 
 ## Plugins vs. Core Features
 


### PR DESCRIPTION
This pull request updates the documentation guidelines in `CONTRIBUTING.md` to help contributors write higher-quality documentation. The main change is the addition of a resource link to guide contributors on what makes documentation effective.

Documentation improvement:

* Added a link to "What makes documentation good?" to the documentation standards section in `CONTRIBUTING.md` to provide contributors with best practices for writing documentation.