### PR TITLE
Added `CHANGELOG.md` to the `extend-exclude` list of typos

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -681,7 +681,7 @@ ignore-vcs = true                    # skip .git/
 ignore-global = true                 # respect global ignores
 ignore-parent = true                 # respect parent ignores
 extend-exclude = [
-    ".git", ".svn", ".hg",
+    ".git", ".svn", ".hg", "CHANGELOG.md",
     ".tox", ".venv", "venv",
     "node_modules", "dist", "build", "target", "out",
     ".mypy_cache", ".pytest_cache", ".ruff_cache", "coverage*",


### PR DESCRIPTION
This pull request makes a minor configuration update to the `pyproject.toml` file. The change ensures that `CHANGELOG.md` is now excluded from linting and formatting tools, alongside other common directories and files.

- Added `CHANGELOG.md` to the `extend-exclude` list in `pyproject.toml` so it will be ignored by tools that use this configuration.