### PR TITLE
feat: async functions for copy_src_example_to_callable.py

### DIFF
--- a/scripts/copy_src_example_to_callable.py
+++ b/scripts/copy_src_example_to_callable.py
@@ -73,7 +73,7 @@ def update_example_section(
     if class_name is None:
         # Module-level function
         for node in ast.walk(tree):
-            if isinstance(node, ast.FunctionDef) and node.name == method_name:
+            if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)) and node.name == method_name:
                 target_node = node
                 break
 
@@ -105,7 +105,7 @@ def update_example_section(
 
         # Find the method
         for node in target_class.body:
-            if isinstance(node, ast.FunctionDef) and node.name == method_name:
+            if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)) and node.name == method_name:
                 target_node = node
                 break
 


### PR DESCRIPTION
Currently `copy_src_example_to_callable.py` doesn't support async functions. This small change allows the script to correctly copy the examples. Previously the script would return 

```
Method from_request not found in class AirForm in /path/air/src/air/forms.py
```

Now its correctly returning 

```
Updated AirForm.from_request in /path/air/src/air/forms.py
```

and copying the example.

# Issue(s)

#814

## Pull request type

Please check the type of change your PR introduces:

- [x] **Bugfix**
- [ ] **New feature**
    - [ ] **Core Air** (Air Tags, Request/Response cycle, etc)
    - [ ] **Optional** (Authentication, CSRF, etc)
    - [ ] **Third-Party Integrated** (Cookbook documentation on using Air databases or a task manager, etc)
    - [ ] **Out-of-Scope** (Formal integration with databases, external task managers, or commercial services etc - won't be accepted, please create a separate project)
- [ ] **Refactoring** (no functional changes, no api changes)
- [ ] **Chore**: Dependency updates, Python version changes, etc.
- [ ] **Build related changes**
- [ ] **Documentation content changes**
- [ ] **Other** (please describe):

## Pull request tasks

The following have been completed for this task:

- [x] **Code changes**
- [ ] **Documentation changes for new or changed features**
- [ ] **Alterations of behavior come with a working implementation in the `examples` folder**
- [ ] **Tests on new or altered behaviors**

## Checklist

- [x] **I have run `just test` and `just qa`, ensuring my code changes passes all existing tests**
- [x] **I have performed a self-review of my own code**
- [x] **I have ensured that there are tests to cover my changes**

