### PR TITLE
docs: fix Air.post src example for copy_src_example_to_callable.py

### DIFF
--- a/examples/src/applications__Air__post.py
+++ b/examples/src/applications__Air__post.py
@@ -1,12 +1,10 @@
-"""Example of using Air.post decorator."""
-
 from pydantic import BaseModel
 
 import air
 
 
 class UserCreate(BaseModel):
-    """User creation model."""
+    # User creation model.
 
     name: str
     email: str
@@ -17,7 +15,7 @@ app = air.Air()
 
 @app.post("/submit")
 def submit_form():
-    """Simple POST endpoint."""
+    # Simple POST endpoint.
     return air.Div(
         air.H2("Form Submitted!"),
         air.P("Thank you for your submission"),
@@ -26,7 +24,7 @@ def submit_form():
 
 @app.post("/users")
 def create_user(user: UserCreate):
-    """POST endpoint with request body."""
+    # POST endpoint with request body.
     return air.Div(
         air.H2("User Created"),
         air.P(f"Name: {user.name}"),

--- a/src/air/applications.py
+++ b/src/air/applications.py
@@ -1097,8 +1097,48 @@ class Air(FastAPI, RouterMixin):
             ),
         ] = generate_unique_id,
     ) -> Callable[[Callable[..., Any]], Callable[..., Any]]:
-        """
-        Add a *path operation* using an HTTP POST operation.
+        """Add a *path operation* using an HTTP POST operation.
+
+        Example:
+
+            from pydantic import BaseModel
+
+            import air
+
+
+            class UserCreate(BaseModel):
+                # User creation model.
+
+                name: str
+                email: str
+
+
+            app = air.Air()
+
+
+            @app.post("/submit")
+            def submit_form():
+                # Simple POST endpoint.
+                return air.Div(
+                    air.H2("Form Submitted!"),
+                    air.P("Thank you for your submission"),
+                )
+
+
+            @app.post("/users")
+            def create_user(user: UserCreate):
+                # POST endpoint with request body.
+                return air.Div(
+                    air.H2("User Created"),
+                    air.P(f"Name: {user.name}"),
+                    air.P(f"Email: {user.email}"),
+                )
+
+
+            if __name__ == "__main__":
+                import uvicorn
+
+                uvicorn.run(app, host="0.0.0.0", port=8000)
         """
 
         def decorator[**P, R](func: Callable[P, MaybeAwaitable[R]]) -> RouteCallable:


### PR DESCRIPTION
Running `copy_src_example_to_callable.py` wasn't picking up `applications__Air__post.py`.

Current output:

```
No Example section found in Air.post
```

Expected output:

```
Updated Air.post in /path/air/src/air/applications.py
```

I updated the doc string in `Air.post` to use `Example:` and replaced doc strings in `applications__Air__post.py` with comments to avoid conflicts when copying the src example.

## Pull request type

Please check the type of change your PR introduces:

- [x] **Bugfix**
- [ ] **New feature**
    - [ ] **Core Air** (Air Tags, Request/Response cycle, etc)
    - [ ] **Optional** (Authentication, CSRF, etc)
    - [ ] **Third-Party Integrated** (Cookbook documentation on using Air databases or a task manager, etc)
    - [ ] **Out-of-Scope** (Formal integration with databases, external task managers, or commercial services etc - won't be accepted, please create a separate project)
- [ ] **Refactoring** (no functional changes, no api changes)
- [ ] **Chore**: Dependency updates, Python version changes, etc.
- [ ] **Build related changes**
- [ ] **Documentation content changes**
- [ ] **Other** (please describe):

## Pull request tasks

The following have been completed for this task:

- [ ] **Code changes**
- [ ] **Documentation changes for new or changed features**
- [ ] **Alterations of behavior come with a working implementation in the `examples` folder**
- [ ] **Tests on new or altered behaviors**

## Checklist

- [x] **I have run `just test` and `just qa`, ensuring my code changes passes all existing tests**
- [x] **I have performed a self-review of my own code**
- [x] **I have ensured that there are tests to cover my changes**
