### PR TITLE
docs: fix Air.page src example

### DIFF
--- a/examples/src/routing__RouterMixin__page.py
+++ b/examples/src/routing__RouterMixin__page.py
@@ -1,6 +1,7 @@
 import air
 
 app = air.Air()
+router = air.AirRouter()
 
 
 @app.page
@@ -8,11 +9,14 @@ def index():  # route is "/"
     return air.H1("I am the home page")
 
 
-@app.page
+@router.page
 def data():  # route is "/data"
     return air.H1("I am the data page")
 
 
-@app.page
+@router.page
 def about_us():  # route is "/about-us"
     return air.H1("I am the about page")
+
+
+app.include_router(router)

--- a/examples/src/routing__RouterMixin__page__test.py
+++ b/examples/src/routing__RouterMixin__page__test.py
@@ -1,6 +1,6 @@
 from fastapi.testclient import TestClient
 
-from .applications__Air__page import app
+from .routing__RouterMixin__page import app
 
 
 def test_page_routes() -> None:

--- a/src/air/routing.py
+++ b/src/air/routing.py
@@ -93,17 +93,21 @@ class RouterMixin:
             app = air.Air()
             router = air.AirRouter()
 
+
             @app.page
-            def index(): # route is "/"
-                return H1("I am the home page")
+            def index():  # route is "/"
+                return air.H1("I am the home page")
+
 
             @router.page
-            def data(): # route is "/data"
-                return H1("I am the home page")
+            def data():  # route is "/data"
+                return air.H1("I am the data page")
+
 
             @router.page
-            def about_us(): # route is "/about-us"
-                return H1("I am the about page")
+            def about_us():  # route is "/about-us"
+                return air.H1("I am the about page")
+
 
             app.include_router(router)
         """


### PR DESCRIPTION
Currently we're seeing this error in `copy_src_example_to_callable.py`:

```
Method page not found in class Air in /path/air/src/air/applications.py
```

This is because `page` is defined in `routing.py`. This PR renames the source example file to `routing__RouterMixin__page.py` and updates the source example file to what the docstring of `page` already has.

After the fix:

```
Updated RouterMixin.page in /path/air/src/air/routing.py
```

## Pull request type

Please check the type of change your PR introduces:

- [x] **Bugfix**
- [ ] **New feature**
    - [ ] **Core Air** (Air Tags, Request/Response cycle, etc)
    - [ ] **Optional** (Authentication, CSRF, etc)
    - [ ] **Third-Party Integrated** (Cookbook documentation on using Air databases or a task manager, etc)
    - [ ] **Out-of-Scope** (Formal integration with databases, external task managers, or commercial services etc - won't be accepted, please create a separate project)
- [ ] **Refactoring** (no functional changes, no api changes)
- [ ] **Chore**: Dependency updates, Python version changes, etc.
- [ ] **Build related changes**
- [ ] **Documentation content changes**
- [ ] **Other** (please describe):

## Pull request tasks

The following have been completed for this task:

- [x] **Code changes**
- [ ] **Documentation changes for new or changed features**
- [ ] **Alterations of behavior come with a working implementation in the `examples` folder**
- [ ] **Tests on new or altered behaviors**

## Checklist

- [x] **I have run `just test` and `just qa`, ensuring my code changes passes all existing tests**
- [x] **I have performed a self-review of my own code**
- [x] **I have ensured that there are tests to cover my changes**

