### PR TITLE
Bugfix: Resolve PEP 563 string annotations in AirRoute

### DIFF
--- a/tests/test_requests_future_annotations.py
+++ b/tests/test_requests_future_annotations.py
@@ -1,0 +1,73 @@
+"""Test that air.Request works with PEP 563 postponed annotations.
+
+This file must have 'from __future__ import annotations' at the module level
+to properly test the fix for string annotations.
+"""
+
+from __future__ import annotations
+
+from fastapi.testclient import TestClient
+
+import air
+
+
+def test_request_param_with_future_annotations() -> None:
+    """Ensure Request parameter works with 'from __future__ import annotations'."""
+    app = air.Air()
+
+    @app.get("/test")
+    def test_endpoint(request: air.Request, *, is_htmx: bool = air.is_htmx_request) -> air.Div:
+        htmx_status = "htmx" if is_htmx else "no-htmx"
+        return air.Div(f"Status: {htmx_status}", class_="status")
+
+    client = TestClient(app)
+    response = client.get("/test")
+    assert response.status_code == 200
+    assert "Status: no-htmx" in response.text
+    assert 'class="status"' in response.text
+
+
+def test_request_param_with_htmx_detection() -> None:
+    """Ensure air.Request works with HTMX detection for both HTMX and non-HTMX requests."""
+    app = air.Air()
+
+    @app.get("/htmx")
+    def htmx_endpoint(request: air.Request, *, is_htmx: bool = air.is_htmx_request) -> air.H1:
+        htmx_status = "HTMX" if is_htmx else "no HTMX"
+        return air.H1(f"Request status: {htmx_status}")
+
+    client = TestClient(app)
+
+    # Test without HTMX header
+    response = client.get("/htmx")
+    assert response.status_code == 200
+    assert "Request status: no HTMX" in response.text
+
+    # Test with HTMX header
+    response = client.get("/htmx", headers={"HX-Request": "true"})
+    assert response.status_code == 200
+    assert "Request status: HTMX" in response.text
+
+
+def test_request_with_query_params() -> None:
+    """Ensure Request parameter doesn't conflict with query parameters."""
+    app = air.Air()
+
+    @app.get("/query")
+    def query_endpoint(request: air.Request, name: str = "World", *, is_htmx: bool = air.is_htmx_request) -> air.P:
+        htmx_status = "HTMX" if is_htmx else "no HTMX"
+        return air.P(f"Hello, {name}! ({htmx_status})")
+
+    client = TestClient(app)
+
+    # Test with default query param
+    response = client.get("/query")
+    assert response.status_code == 200
+    assert "Hello, World!" in response.text
+    assert "no HTMX" in response.text
+
+    # Test with custom query param
+    response = client.get("/query?name=Alice")
+    assert response.status_code == 200
+    assert "Hello, Alice!" in response.text
+    assert "no HTMX" in response.text


### PR DESCRIPTION
When using `from __future__ import annotations`, Python converts all annotations to strings (PEP 563). This causes issues with Air's wrapper pattern because:

1. Air wraps user functions to handle async results
2. The wrapper is defined in `routing.py`, so `wrapper.__globals__` points to this module
3. FastAPI inspects the wrapper and tries to resolve string annotations
4. But it can't find `air.Request` in `routing.py`'s globals, since it's in the user's module

We can fix this by using `get_type_hints()` which resolves the string annotations to real types using the function's `__globals__` (which `@wraps` copies from the original).

We then cache the resolved signature so FastAPI doesn't need to re-inspect it.

# Issue(s)

#755 

## Pull request type

Please check the type of change your PR introduces:

- [x] **Bugfix**
- [ ] **New feature**
    - [ ] **Core Air** (Air Tags, Request/Response cycle, etc)
    - [ ] **Optional** (Authentication, CSRF, etc)
    - [ ] **Third-Party Integrated** (Cookbook documentation on using Air databases or a task manager, etc)
    - [ ] **Out-of-Scope** (Formal integration with databases, external task managers, or commercial services etc - won't be accepted, please create a separate project)
- [ ] **Refactoring** (no functional changes, no api changes)
- [ ] **Chore**: Dependency updates, Python version changes, etc.
- [ ] **Build related changes**
- [ ] **Documentation content changes**
- [ ] **Other** (please describe):

## Pull request tasks

The following have been completed for this task:

- [x] **Code changes**
- [ ] **Documentation changes for new or changed features**
- [ ] **Alterations of behavior come with a working implementation in the `examples` folder**
- [x] **Tests on new or altered behaviors**

## Checklist

- [x] **I have run `just test` and `just qa`, ensuring my code changes passes all existing tests**
- [x] **I have performed a self-review of my own code**
- [x] **I have ensured that there are tests to cover my changes**
