### PR TITLE
Fixes 895: Exclude htmlcov directory from codespell checks

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -639,7 +639,7 @@ builtin = 'clear,rare,usage,informal,names,code'
 skip = '''
 .idea,.git,.svn,.hg,site,.tox,.venv,venv,node_modules,dist,build,.mypy_cache,.pytest_cache,.ruff_cache,
 coverage*,target,out,*.toml,*.png,*.jpg,*.jpeg,*.gif,*.bmp,*.ico,*.svg,*.pdf,*.zip,*.gz,*.tgz,
-*.bz2,*.xz,*.7z,*.min.js,*.min.css,*.lock,*.pyc,.DS_Store,.coverage,.cov_html,.benchmarks,.cache
+*.bz2,*.xz,*.7z,*.min.js,*.min.css,*.lock,*.pyc,.DS_Store,.coverage,.cov_html,htmlcov,.benchmarks,.cache
 '''
 # Ignore typos inside URLs/emails to avoid breaking links
 uri-ignore-words-list = '*'


### PR DESCRIPTION
The htmlcov directory contains auto-generated HTML coverage reports that trigger false positives (e.g., "mis" for "missing" in CSS).

This is just a minor config change to ignore it

# Issue(s)

Fixes #895 

## Pull request type
<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [x] **Bugfix**
- [ ] **New feature**
    - [ ] **Core Air** (Air Tags, Request/Response cycle, etc)
    - [ ] **Optional** (Authentication, CSRF, etc)
    - [ ] **Third-Party Integrated** (Cookbook documentation on using Air databases or a task manager, etc)
    - [ ] **Out-of-Scope** (Formal integration with databases, external task managers, or commercial services etc - won't be accepted, please create a separate project)
- [ ] **Refactoring** (no functional changes, no api changes)
- [ ] **Chore**: Dependency updates, Python version changes, etc.
- [ ] **Build related changes**
- [ ] **Documentation content changes**
- [ ] **Other** (please describe):

## Pull request tasks

The following have been completed for this task:

- [ ] **Config changes**

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] **I have run `just test` and `just qa`, ensuring my code changes passes all existing tests**
- [x] **I have performed a self-review of my own code**
- [ ] **I have ensured that there are tests to cover my changes**