### PR TITLE
Renovate to update by version not hash

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -12,7 +12,6 @@
     ":semanticCommitScope(deps)",
     ":maintainLockFilesWeekly",
     ":prHourlyLimitNone",
-    "helpers:pinGitHubActionDigests",
   ],
   // Keep semantic commits explicit even though the preset already sets the scope
   semanticCommitScope: "deps",


### PR DESCRIPTION
Renovate is updating some things by hashes, which makes it much harder for maintainers to be able to tell if something is being moved forward or not. By not being mnemonic, it makes it much harder to diagnose potential bugs and errors that may arise.

See this example PR of what we don't want: https://github.com/feldroy/air/pull/902/changes

## Pull request type
<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] **Bugfix**
- [ ] **New feature**
    - [ ] **Core Air** (Air Tags, Request/Response cycle, etc)
    - [ ] **Optional** (Authentication, CSRF, etc)
    - [ ] **Third-Party Integrated** (Cookbook documentation on using Air databases or a task manager, etc)
    - [ ] **Out-of-Scope** (Formal integration with databases, external task managers, or commercial services etc - won't be accepted, please create a separate project)
- [ ] **Refactoring** (no functional changes, no api changes)
- [x] **Chore**: Dependency updates, Python version changes, etc.
- [x] **Build related changes**
- [ ] **Documentation content changes**
- [ ] **Other** (please describe):

## Pull request tasks

The following have been completed for this task:

- [x] **Code changes**
- [ ] **Documentation changes for new or changed features**
- [ ] **Alterations of behavior come with a working implementation in the `examples` folder**
- [ ] **Tests on new or altered behaviors**

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] **I have run `just test` and `just qa`, ensuring my code changes passes all existing tests**
- [x] **I have performed a self-review of my own code**
- [x] **I have ensured that there are tests to cover my changes**
