### PR TITLE
chore: enable Ruff rule A (builtins shadowing)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -308,7 +308,7 @@ select = [
     "BLE", # https://docs.astral.sh/ruff/rules/#flake8-blind-except-ble
     "FBT", # https://docs.astral.sh/ruff/rules/#flake8-boolean-trap-fbt
     "B", # https://docs.astral.sh/ruff/rules/#flake8-bugbear-b
-    #    "A",      # https://docs.astral.sh/ruff/rules/#flake8-builtins-a
+    "A", # https://docs.astral.sh/ruff/rules/#flake8-builtins-a
     "C4", # https://docs.astral.sh/ruff/rules/#flake8-comprehensions-c4
     "EM", # https://docs.astral.sh/ruff/rules/#flake8-errmsg-em
     #    "FIX",    # https://docs.astral.sh/ruff/rules/#flake8-fixme-fix
@@ -371,10 +371,15 @@ ignore = [
 ]
 "examples/**.py" = [
     "T20", # https://docs.astral.sh/ruff/rules/#flake8-print-t20
+    "A004", # https://docs.astral.sh/ruff/rules/builtin-import-shadowing/
 ]
 "scripts/copy_src_example_to_callable.py" = ["C901"]
+"scripts/missing_examples.py" = ["A004"]
 "src/air/tags/utils.py" = ["PLC0415"]
 "src/air/tags/models/base.py" = ["PLC0415"]
+"src/air/tags/models/svg.py" = ["A002"]
+"src/air/tags/models/stock.py" = ["A002"]
+"src/air/forms.py" = ["A002"]
 "tests/test_templating.py" = ["PLC2701"]
 "tests/test_responses.py" = ["PLC0415"]
 "examples/airblog/airblog.py" = ["INP001"]


### PR DESCRIPTION
- Enabled Ruff rule A (shadowing Python builtins) across the codebase.
- Added per-file ignores for intentional shadowing:
  - src/air/forms.py (repr, type, etc.)
  - src/air/tags/models/stock.py and svg.py (id, type, etc.)
  - examples/** (rich.print)
  - scripts/missing_examples.py (rich.print)
- Ensures code quality and prevents accidental shadowing.

# Issue(s)

- #644: enabling Ruff rule A and cleaning up shadowed builtins.

## Pull request type

- [ ] **Bugfix**
- [ ] **New feature**
    - [ ] **Core Air** (Air Tags, Request/Response cycle, etc)
    - [ ] **Optional** (Authentication, CSRF, etc)
    - [ ] **Third-Party Integrated** (Cookbook documentation on using Air databases or a task manager, etc)
    - [ ] **Out-of-Scope** (Formal integration with databases, external task managers, or commercial services etc - won't be accepted, please create a separate project)
- [ ] **Refactoring** (no functional changes, no api changes)
- [x] **Chore**: Dependency updates, Python version changes, linting rules update
- [ ] **Build related changes**
- [ ] **Documentation content changes**
- [ ] **Other** (please describe):

## Pull request tasks

The following have been completed for this task:

- [ ] **Code changes**
- [ ] **Documentation changes for new or changed features**
- [ ] **Alterations of behavior come with a working implementation in the `examples` folder**
- [ ] **Tests on new or altered behaviors**

## Checklist

- [x] **I have run `just test` and `just qa`, ensuring my code changes pass all existing tests**
- [x] **I have performed a self-review of my own code**
- [x] **I have ensured that there are tests to cover my changes**

## Other information

This PR enables Ruff's rule A to prevent accidental shadowing of Python builtins. Intentional shadowing is allowed per-file via `per-file-ignores` in `pyproject.toml`.