### PR TITLE
Rename open to open_ to prevent builtin shadowing in tags

### DIFF
--- a/src/air/tags/constants.py
+++ b/src/air/tags/constants.py
@@ -36,6 +36,7 @@ ATTRIBUTES_TO_AIR: Final = frozendict({
     "type": "type_",
     "max": "max_",
     "min": "min_",
+    "open": "open_",
 })
 ATTRIBUTES_TO_HTML: Final = frozendict({
     "class_": "class",
@@ -46,6 +47,7 @@ ATTRIBUTES_TO_HTML: Final = frozendict({
     "type_": "type",
     "max_": "max",
     "min_": "min",
+    "open_": "open",
 })
 BOOLEAN_HTML_ATTRIBUTES: Final = {
     # https://html.spec.whatwg.org/multipage/indices.html#attributes-3

--- a/src/air/tags/models/stock.py
+++ b/src/air/tags/models/stock.py
@@ -660,7 +660,7 @@ class Details(BaseTag):
 
     Args:
         children: Tags, strings, or other rendered content.
-        open: Specifies that the details should be visible (open) to the user.
+        open_: Specifies that the details should be visible (open) to the user.
         class_: Substituted as the DOM `class` attribute.
         id_: DOM ID attribute.
         style: Inline style attribute.
@@ -670,7 +670,7 @@ class Details(BaseTag):
     def __init__(
         self,
         *children: Renderable,
-        open: str | None = None,
+        open_: str | None = None,
         class_: str | None = None,
         id_: str | None = None,
         style: str | None = None,
@@ -706,7 +706,7 @@ class Dialog(BaseTag):
 
     Args:
         children: Tags, strings, or other rendered content.
-        open: Specifies that the dialog box should be visible (open) to the user.
+        open_: Specifies that the dialog box should be visible (open) to the user.
         class_: Substituted as the DOM `class` attribute.
         id_: DOM ID attribute.
         style: Inline style attribute.
@@ -716,7 +716,7 @@ class Dialog(BaseTag):
     def __init__(
         self,
         *children: Renderable,
-        open: str | None = None,
+        open_: str | None = None,
         class_: str | None = None,
         id_: str | None = None,
         style: str | None = None,

--- a/tests/tags/test_stock_tags_coverage.py
+++ b/tests/tags/test_stock_tags_coverage.py
@@ -34,9 +34,9 @@ def test_stock_tags_comprehensive_coverage() -> None:
         air.Datalist("Datalist content", id_="browsers"),
         air.Dd("Definition description", class_="definition"),
         air.Del("Deleted text", datetime="2023-01-01", class_="deleted"),
-        air.Details("Details content", open=True, class_="details"),
+        air.Details("Details content", open_=True, class_="details"),
         air.Dfn("Definition", title="Definition title", class_="definition"),
-        air.Dialog("Dialog content", open=False, id_="modal"),
+        air.Dialog("Dialog content", open_=False, id_="modal"),
         air.Div("Div content", class_="container", id_="main"),
         air.Dl("Description list", class_="description-list"),
         air.Dt("Definition term", class_="term"),
@@ -227,8 +227,8 @@ def test_stock_tags_edge_cases() -> None:
         air.Option("Option", selected=True, disabled=False),
         air.Audio(controls=True, autoplay=False, loop=None, muted=True),
         air.Video(controls=True, autoplay=False, muted=True, loop=False),
-        air.Details("Details", open=True),
-        air.Dialog("Dialog", open=False),
+        air.Details("Details", open_=True),
+        air.Dialog("Dialog", open_=False),
     ]
 
     for tag in boolean_attr_tags:


### PR DESCRIPTION
# Issue(s)

#644 

## Pull request type

Please check the type of change your PR introduces:

- [x] **Bugfix**
- [ ] **New feature**
    - [ ] **Core Air** (Air Tags, Request/Response cycle, etc)
    - [ ] **Optional** (Authentication, CSRF, etc)
    - [ ] **Third-Party Integrated** (Cookbook documentation on using Air databases or a task manager, etc)
    - [ ] **Out-of-Scope** (Formal integration with databases, external task managers, or commercial services etc - won't be accepted, please create a separate project)
- [ ] **Refactoring** (no functional changes, no api changes)
- [ ] **Chore**: Dependency updates, Python version changes, etc.
- [ ] **Build related changes**
- [ ] **Documentation content changes**
- [ ] **Other** (please describe):

## Pull request tasks

The following have been completed for this task:

- [x] **Code changes**
- [ ] **Documentation changes for new or changed features**
- [ ] **Alterations of behavior come with a working implementation in the `examples` folder**
- [ ] **Tests on new or altered behaviors**

## Checklist

- [x] **I have run `just test` and `just qa`, ensuring my code changes passes all existing tests**
- [x] **I have performed a self-review of my own code**
- [x] **I have ensured that there are tests to cover my changes**
