### PR TITLE
Rename reversed to reversed_ to prevent builtin shadowing in tags

### DIFF
--- a/src/air/tags/constants.py
+++ b/src/air/tags/constants.py
@@ -37,6 +37,7 @@ ATTRIBUTES_TO_AIR: Final = frozendict({
     "max": "max_",
     "min": "min_",
     "open": "open_",
+    "reversed": "reversed_",
 })
 ATTRIBUTES_TO_HTML: Final = frozendict({
     "class_": "class",
@@ -48,6 +49,7 @@ ATTRIBUTES_TO_HTML: Final = frozendict({
     "max_": "max",
     "min_": "min",
     "open_": "open",
+    "reversed_": "reversed",
 })
 BOOLEAN_HTML_ATTRIBUTES: Final = {
     # https://html.spec.whatwg.org/multipage/indices.html#attributes-3

--- a/src/air/tags/models/stock.py
+++ b/src/air/tags/models/stock.py
@@ -1812,7 +1812,7 @@ class Ol(BaseTag):
     Args:
         children: Tags, strings, or other rendered content.
         compact: Specifies that the list should be rendered in a compact style.
-        reversed: Specifies that the list order should be descending.
+        reversed_: Specifies that the list order should be descending.
         start: Specifies the start value of an ordered list.
         type_: Specifies the kind of marker to use in the list.
         class_: Substituted as the DOM `class` attribute.
@@ -1825,7 +1825,7 @@ class Ol(BaseTag):
         self,
         *children: Renderable,
         compact: str | None = None,
-        reversed: str | None = None,
+        reversed_: str | None = None,
         start: str | None = None,
         type_: str | None = None,
         class_: str | None = None,


### PR DESCRIPTION
# Issue(s)

#644 

## Pull request type

Please check the type of change your PR introduces:

- [x] **Bugfix**
- [ ] **New feature**
    - [ ] **Core Air** (Air Tags, Request/Response cycle, etc)
    - [ ] **Optional** (Authentication, CSRF, etc)
    - [ ] **Third-Party Integrated** (Cookbook documentation on using Air databases or a task manager, etc)
    - [ ] **Out-of-Scope** (Formal integration with databases, external task managers, or commercial services etc - won't be accepted, please create a separate project)
- [ ] **Refactoring** (no functional changes, no api changes)
- [ ] **Chore**: Dependency updates, Python version changes, etc.
- [ ] **Build related changes**
- [ ] **Documentation content changes**
- [ ] **Other** (please describe):

## Pull request tasks

The following have been completed for this task:

- [x] **Code changes**
- [ ] **Documentation changes for new or changed features**
- [ ] **Alterations of behavior come with a working implementation in the `examples` folder**
- [ ] **Tests on new or altered behaviors**

## Checklist

- [x] **I have run `just test` and `just qa`, ensuring my code changes passes all existing tests**
- [x] **I have performed a self-review of my own code**
- [x] **I have ensured that there are tests to cover my changes**
