### PR TITLE
Remove air_tag_source_samples.py from ruff lint per-file-ignore

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -379,7 +379,6 @@ ignore = [
 "scripts/copy_src_example_to_callable.py" = ["C901"]
 "scripts/missing_examples.py" = ["A004"]
 "src/air/forms.py" = ["A002"]
-"examples/samples/air_tag_source_samples.py" = ["W505"]
 
 [tool.ruff.lint.flake8-import-conventions]
 # Declare the banned `from` imports.


### PR DESCRIPTION
This PR cleans up an ignore that is no longer needed.

# Issue(s)

#636

## Pull request type

Please check the type of change your PR introduces:

- [ ] **Bugfix**
- [ ] **New feature**
    - [ ] **Core Air** (Air Tags, Request/Response cycle, etc)
    - [ ] **Optional** (Authentication, CSRF, etc)
    - [ ] **Third-Party Integrated** (Cookbook documentation on using Air databases or a task manager, etc)
    - [ ] **Out-of-Scope** (Formal integration with databases, external task managers, or commercial services etc - won't be accepted, please create a separate project)
- [ ] **Refactoring** (no functional changes, no api changes)
- [x] **Chore**: Dependency updates, Python version changes, etc.
- [ ] **Build related changes**
- [ ] **Documentation content changes**
- [ ] **Other** (please describe):

## Pull request tasks

The following have been completed for this task:

- [x] **Code changes**
- [ ] **Documentation changes for new or changed features**
- [ ] **Alterations of behavior come with a working implementation in the `examples` folder**
- [ ] **Tests on new or altered behaviors**

## Checklist

- [x] **I have run `just test` and `just qa`, ensuring my code changes passes all existing tests**
- [x] **I have performed a self-review of my own code**
- [x] **I have ensured that there are tests to cover my changes**
