### PR TITLE
hotfix: now renovate will upgrade the just-install action correctly!

### DIFF
--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -51,7 +51,9 @@ jobs:
       - uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0
         with:
           persist-credentials: false
-      - uses: taiki-e/install-action@d8510c9acdeaed29d14bb7104dfeb31e4b8effc8 # just
+      - uses: taiki-e/install-action@dfcb1ee29051d97c8d0f2d437199570008fd5612 # 2.65.15
+        with:
+          tool: just
       - uses: astral-sh/setup-uv@1e862dfacbd1d6d858c55d9b792c756523627244 # v7.1.4
         with:
           enable-cache: false
@@ -65,7 +67,9 @@ jobs:
       - uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0
         with:
           persist-credentials: false
-      - uses: taiki-e/install-action@d8510c9acdeaed29d14bb7104dfeb31e4b8effc8 # just
+      - uses: taiki-e/install-action@dfcb1ee29051d97c8d0f2d437199570008fd5612 # 2.65.15
+        with:
+          tool: just
       - uses: astral-sh/setup-uv@1e862dfacbd1d6d858c55d9b792c756523627244 # v7.1.4
         with:
           enable-cache: false
@@ -87,7 +91,9 @@ jobs:
       - uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0
         with:
           persist-credentials: false
-      - uses: taiki-e/install-action@d8510c9acdeaed29d14bb7104dfeb31e4b8effc8 # just
+      - uses: taiki-e/install-action@dfcb1ee29051d97c8d0f2d437199570008fd5612 # 2.65.15
+        with:
+          tool: just
       - uses: astral-sh/setup-uv@1e862dfacbd1d6d858c55d9b792c756523627244 # v7.1.4
         with:
           python-version: ${{ matrix.python-version }}
@@ -105,7 +111,9 @@ jobs:
       - uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0
         with:
           persist-credentials: false
-      - uses: taiki-e/install-action@d8510c9acdeaed29d14bb7104dfeb31e4b8effc8 # just
+      - uses: taiki-e/install-action@dfcb1ee29051d97c8d0f2d437199570008fd5612 # 2.65.15
+        with:
+          tool: just
       - uses: astral-sh/setup-uv@1e862dfacbd1d6d858c55d9b792c756523627244 # v7.1.4
         with:
           enable-cache: false

--- a/.github/workflows/publish-docs.yaml
+++ b/.github/workflows/publish-docs.yaml
@@ -33,6 +33,8 @@ jobs:
           enable-cache: true
           cache-dependency-glob: uv.lock
       - name: Install just
-        uses: taiki-e/install-action@d8510c9acdeaed29d14bb7104dfeb31e4b8effc8 # just
+        uses: taiki-e/install-action@dfcb1ee29051d97c8d0f2d437199570008fd5612 # 2.65.15
+        with:
+          tool: just
       - name: Deploy the documentation to GitHub Pages
         run: just doc-build


### PR DESCRIPTION
> [!IMPORTANT]
> Hotfix!!! 

This pull request updates the GitHub Actions workflow configuration to use a newer version of the `taiki-e/install-action` for installing the `just` tool. The change ensures that the installation step is more explicit and uses the recommended configuration for specifying the tool to be installed.

Updates to CI and documentation workflows:

* Updated the `taiki-e/install-action` version from `d8510c9acdeaed29d14bb7104dfeb31e4b8effc8` to `dfcb1ee29051d97c8d0f2d437199570008fd5612` in `.github/workflows/CI.yaml` and `.github/workflows/publish-docs.yaml`, ensuring compatibility with the latest action version. [[1]](diffhunk://#diff-b268bb7dc66e8638921e223098a11eabb92b424875ec72a19d6145dc1efbe3f2L54-R56) [[2]](diffhunk://#diff-b268bb7dc66e8638921e223098a11eabb92b424875ec72a19d6145dc1efbe3f2L68-R72) [[3]](diffhunk://#diff-b268bb7dc66e8638921e223098a11eabb92b424875ec72a19d6145dc1efbe3f2L90-R96) [[4]](diffhunk://#diff-b268bb7dc66e8638921e223098a11eabb92b424875ec72a19d6145dc1efbe3f2L108-R116) [[5]](diffhunk://#diff-69250281a3f8b6ed9c93d9d9d8d92aa49e2105c37fe83fd22168ec5ab85250bdL36-R38)
* Added the `tool: just` input to the installation step, making the tool installation explicit and future-proof. [[1]](diffhunk://#diff-b268bb7dc66e8638921e223098a11eabb92b424875ec72a19d6145dc1efbe3f2L54-R56) [[2]](diffhunk://#diff-b268bb7dc66e8638921e223098a11eabb92b424875ec72a19d6145dc1efbe3f2L68-R72) [[3]](diffhunk://#diff-b268bb7dc66e8638921e223098a11eabb92b424875ec72a19d6145dc1efbe3f2L90-R96) [[4]](diffhunk://#diff-b268bb7dc66e8638921e223098a11eabb92b424875ec72a19d6145dc1efbe3f2L108-R116) [[5]](diffhunk://#diff-69250281a3f8b6ed9c93d9d9d8d92aa49e2105c37fe83fd22168ec5ab85250bdL36-R38)