### PR TITLE
Remove extraneous HTTP method args from AirRouter

### DIFF
--- a/src/air/routing.py
+++ b/src/air/routing.py
@@ -19,7 +19,6 @@ from warnings import deprecated as warnings_deprecated
 from fastapi import params
 from fastapi.params import Depends
 from fastapi.routing import APIRoute, APIRouter
-from fastapi.types import IncEx
 from fastapi.utils import generate_unique_id
 from starlette.responses import Response
 from starlette.routing import (
@@ -545,40 +544,6 @@ class AirRouter(RouterMixin):
             ),
         ],
         *,
-        response_model: Annotated[
-            Any,
-            Doc(
-                """
-                The type to use for the response.
-
-                It could be any valid Pydantic *field* type. So, it doesn't have to
-                be a Pydantic model, it could be other things, like a `list`, `dict`,
-                etc.
-
-                It will be used for:
-
-                * Documentation: the generated OpenAPI (and the UI at `/docs`) will
-                    show it as the response (JSON Schema).
-                * Serialization: you could return an arbitrary object and the
-                    `response_model` would be used to serialize that object into the
-                    corresponding JSON.
-                * Filtering: the JSON sent to the client will only contain the data
-                    (fields) defined in the `response_model`. If you returned an object
-                    that contains an attribute `password` but the `response_model` does
-                    not include that field, the JSON sent to the client would not have
-                    that `password`.
-                * Validation: whatever you return will be serialized with the
-                    `response_model`, converting any data as necessary to generate the
-                    corresponding JSON. But if the data in the object returned is not
-                    valid, that would mean a violation of the contract with the client,
-                    so it's an error from the API developer. So, FastAPI will raise an
-                    error and return a 500 error code (Internal Server Error).
-
-                Read more about it in the
-                [FastAPI docs for Response Model](https://fastapi.tiangolo.com/tutorial/response-model/).
-                """
-            ),
-        ] = None,
         status_code: Annotated[
             int | None,
             Doc(
@@ -698,94 +663,6 @@ class AirRouter(RouterMixin):
                 """
             ),
         ] = None,
-        response_model_include: Annotated[
-            IncEx | None,
-            Doc(
-                """
-                Configuration passed to Pydantic to include only certain fields in the
-                response data.
-
-                Read more about it in the
-                [FastAPI docs for Response Model - Return Type](https://fastapi.tiangolo.com/tutorial/response-model/#response_model_include-and-response_model_exclude).
-                """
-            ),
-        ] = None,
-        response_model_exclude: Annotated[
-            IncEx | None,
-            Doc(
-                """
-                Configuration passed to Pydantic to exclude certain fields in the
-                response data.
-
-                Read more about it in the
-                [FastAPI docs for Response Model - Return Type](https://fastapi.tiangolo.com/tutorial/response-model/#response_model_include-and-response_model_exclude).
-                """
-            ),
-        ] = None,
-        response_model_by_alias: Annotated[
-            bool,
-            Doc(
-                """
-                Configuration passed to Pydantic to define if the response model
-                should be serialized by alias when an alias is used.
-
-                Read more about it in the
-                [FastAPI docs for Response Model - Return Type](https://fastapi.tiangolo.com/tutorial/response-model/#response_model_include-and-response_model_exclude).
-                """
-            ),
-        ] = True,
-        response_model_exclude_unset: Annotated[
-            bool,
-            Doc(
-                """
-                Configuration passed to Pydantic to define if the response data
-                should have all the fields, including the ones that were not set and
-                have their default values. This is different from
-                `response_model_exclude_defaults` in that if the fields are set,
-                they will be included in the response, even if the value is the same
-                as the default.
-
-                When `True`, default values are omitted from the response.
-
-                Read more about it in the
-                [FastAPI docs for Response Model - Return Type](https://fastapi.tiangolo.com/tutorial/response-model/#use-the-response_model_exclude_unset-parameter).
-                """
-            ),
-        ] = False,
-        response_model_exclude_defaults: Annotated[
-            bool,
-            Doc(
-                """
-                Configuration passed to Pydantic to define if the response data
-                should have all the fields, including the ones that have the same value
-                as the default. This is different from `response_model_exclude_unset`
-                in that if the fields are set but contain the same default values,
-                they will be excluded from the response.
-
-                When `True`, default values are omitted from the response.
-
-                Read more about it in the
-                [FastAPI docs for Response Model - Return Type](https://fastapi.tiangolo.com/tutorial/response-model/#use-the-response_model_exclude_unset-parameter).
-                """
-            ),
-        ] = False,
-        response_model_exclude_none: Annotated[
-            bool,
-            Doc(
-                """
-                Configuration passed to Pydantic to define if the response data should
-                exclude fields set to `None`.
-
-                This is much simpler (less smart) than `response_model_exclude_unset`
-                and `response_model_exclude_defaults`. You probably want to use one of
-                those two instead of this one, as those allow returning `None` values
-                when it makes sense.
-
-                Read more about it in the
-                [FastAPI docs for Response Model - Return Type](https://fastapi.tiangolo.com/tutorial/response-model/#response_model_exclude_none).
-                """
-            ),
-        ] = False,
         include_in_schema: Annotated[
             bool,
             Doc(
@@ -901,7 +778,7 @@ class AirRouter(RouterMixin):
 
             decorated = self._router.get(
                 path,
-                response_model=response_model,
+                response_model=None,
                 status_code=status_code,
                 tags=tags,
                 dependencies=dependencies,
@@ -911,12 +788,12 @@ class AirRouter(RouterMixin):
                 responses=responses,
                 deprecated=deprecated,
                 operation_id=operation_id,
-                response_model_include=response_model_include,
-                response_model_exclude=response_model_exclude,
-                response_model_by_alias=response_model_by_alias,
-                response_model_exclude_unset=response_model_exclude_unset,
-                response_model_exclude_defaults=response_model_exclude_defaults,
-                response_model_exclude_none=response_model_exclude_none,
+                response_model_include=None,
+                response_model_exclude=None,
+                response_model_by_alias=True,
+                response_model_exclude_unset=False,
+                response_model_exclude_defaults=False,
+                response_model_exclude_none=False,
                 include_in_schema=include_in_schema,
                 response_class=response_class,
                 name=name,
@@ -943,40 +820,6 @@ class AirRouter(RouterMixin):
             ),
         ],
         *,
-        response_model: Annotated[
-            Any,
-            Doc(
-                """
-                The type to use for the response.
-
-                It could be any valid Pydantic *field* type. So, it doesn't have to
-                be a Pydantic model, it could be other things, like a `list`, `dict`,
-                etc.
-
-                It will be used for:
-
-                * Documentation: the generated OpenAPI (and the UI at `/docs`) will
-                    show it as the response (JSON Schema).
-                * Serialization: you could return an arbitrary object and the
-                    `response_model` would be used to serialize that object into the
-                    corresponding JSON.
-                * Filtering: the JSON sent to the client will only contain the data
-                    (fields) defined in the `response_model`. If you returned an object
-                    that contains an attribute `password` but the `response_model` does
-                    not include that field, the JSON sent to the client would not have
-                    that `password`.
-                * Validation: whatever you return will be serialized with the
-                    `response_model`, converting any data as necessary to generate the
-                    corresponding JSON. But if the data in the object returned is not
-                    valid, that would mean a violation of the contract with the client,
-                    so it's an error from the API developer. So, FastAPI will raise an
-                    error and return a 500 error code (Internal Server Error).
-
-                Read more about it in the
-                [FastAPI docs for Response Model](https://fastapi.tiangolo.com/tutorial/response-model/).
-                """
-            ),
-        ] = None,
         status_code: Annotated[
             int | None,
             Doc(
@@ -1096,94 +939,6 @@ class AirRouter(RouterMixin):
                 """
             ),
         ] = None,
-        response_model_include: Annotated[
-            IncEx | None,
-            Doc(
-                """
-                Configuration passed to Pydantic to include only certain fields in the
-                response data.
-
-                Read more about it in the
-                [FastAPI docs for Response Model - Return Type](https://fastapi.tiangolo.com/tutorial/response-model/#response_model_include-and-response_model_exclude).
-                """
-            ),
-        ] = None,
-        response_model_exclude: Annotated[
-            IncEx | None,
-            Doc(
-                """
-                Configuration passed to Pydantic to exclude certain fields in the
-                response data.
-
-                Read more about it in the
-                [FastAPI docs for Response Model - Return Type](https://fastapi.tiangolo.com/tutorial/response-model/#response_model_include-and-response_model_exclude).
-                """
-            ),
-        ] = None,
-        response_model_by_alias: Annotated[
-            bool,
-            Doc(
-                """
-                Configuration passed to Pydantic to define if the response model
-                should be serialized by alias when an alias is used.
-
-                Read more about it in the
-                [FastAPI docs for Response Model - Return Type](https://fastapi.tiangolo.com/tutorial/response-model/#response_model_include-and-response_model_exclude).
-                """
-            ),
-        ] = True,
-        response_model_exclude_unset: Annotated[
-            bool,
-            Doc(
-                """
-                Configuration passed to Pydantic to define if the response data
-                should have all the fields, including the ones that were not set and
-                have their default values. This is different from
-                `response_model_exclude_defaults` in that if the fields are set,
-                they will be included in the response, even if the value is the same
-                as the default.
-
-                When `True`, default values are omitted from the response.
-
-                Read more about it in the
-                [FastAPI docs for Response Model - Return Type](https://fastapi.tiangolo.com/tutorial/response-model/#use-the-response_model_exclude_unset-parameter).
-                """
-            ),
-        ] = False,
-        response_model_exclude_defaults: Annotated[
-            bool,
-            Doc(
-                """
-                Configuration passed to Pydantic to define if the response data
-                should have all the fields, including the ones that have the same value
-                as the default. This is different from `response_model_exclude_unset`
-                in that if the fields are set but contain the same default values,
-                they will be excluded from the response.
-
-                When `True`, default values are omitted from the response.
-
-                Read more about it in the
-                [FastAPI docs for Response Model - Return Type](https://fastapi.tiangolo.com/tutorial/response-model/#use-the-response_model_exclude_unset-parameter).
-                """
-            ),
-        ] = False,
-        response_model_exclude_none: Annotated[
-            bool,
-            Doc(
-                """
-                Configuration passed to Pydantic to define if the response data should
-                exclude fields set to `None`.
-
-                This is much simpler (less smart) than `response_model_exclude_unset`
-                and `response_model_exclude_defaults`. You probably want to use one of
-                those two instead of this one, as those allow returning `None` values
-                when it makes sense.
-
-                Read more about it in the
-                [FastAPI docs for Response Model - Return Type](https://fastapi.tiangolo.com/tutorial/response-model/#response_model_exclude_none).
-                """
-            ),
-        ] = False,
         include_in_schema: Annotated[
             bool,
             Doc(
@@ -1282,7 +1037,7 @@ class AirRouter(RouterMixin):
 
             decorated = self._router.post(
                 path,
-                response_model=response_model,
+                response_model=None,
                 status_code=status_code,
                 tags=tags,
                 dependencies=dependencies,
@@ -1292,12 +1047,12 @@ class AirRouter(RouterMixin):
                 responses=responses,
                 deprecated=deprecated,
                 operation_id=operation_id,
-                response_model_include=response_model_include,
-                response_model_exclude=response_model_exclude,
-                response_model_by_alias=response_model_by_alias,
-                response_model_exclude_unset=response_model_exclude_unset,
-                response_model_exclude_defaults=response_model_exclude_defaults,
-                response_model_exclude_none=response_model_exclude_none,
+                response_model_include=None,
+                response_model_exclude=None,
+                response_model_by_alias=True,
+                response_model_exclude_unset=False,
+                response_model_exclude_defaults=False,
+                response_model_exclude_none=False,
                 include_in_schema=include_in_schema,
                 response_class=response_class,
                 name=name,
@@ -1324,40 +1079,6 @@ class AirRouter(RouterMixin):
             ),
         ],
         *,
-        response_model: Annotated[
-            Any,
-            Doc(
-                """
-                The type to use for the response.
-
-                It could be any valid Pydantic *field* type. So, it doesn't have to
-                be a Pydantic model, it could be other things, like a `list`, `dict`,
-                etc.
-
-                It will be used for:
-
-                * Documentation: the generated OpenAPI (and the UI at `/docs`) will
-                    show it as the response (JSON Schema).
-                * Serialization: you could return an arbitrary object and the
-                    `response_model` would be used to serialize that object into the
-                    corresponding JSON.
-                * Filtering: the JSON sent to the client will only contain the data
-                    (fields) defined in the `response_model`. If you returned an object
-                    that contains an attribute `password` but the `response_model` does
-                    not include that field, the JSON sent to the client would not have
-                    that `password`.
-                * Validation: whatever you return will be serialized with the
-                    `response_model`, converting any data as necessary to generate the
-                    corresponding JSON. But if the data in the object returned is not
-                    valid, that would mean a violation of the contract with the client,
-                    so it's an error from the API developer. So, FastAPI will raise an
-                    error and return a 500 error code (Internal Server Error).
-
-                Read more about it in the
-                [FastAPI docs for Response Model](https://fastapi.tiangolo.com/tutorial/response-model/).
-                """
-            ),
-        ] = None,
         status_code: Annotated[
             int | None,
             Doc(
@@ -1477,94 +1198,6 @@ class AirRouter(RouterMixin):
                 """
             ),
         ] = None,
-        response_model_include: Annotated[
-            IncEx | None,
-            Doc(
-                """
-                Configuration passed to Pydantic to include only certain fields in the
-                response data.
-
-                Read more about it in the
-                [FastAPI docs for Response Model - Return Type](https://fastapi.tiangolo.com/tutorial/response-model/#response_model_include-and-response_model_exclude).
-                """
-            ),
-        ] = None,
-        response_model_exclude: Annotated[
-            IncEx | None,
-            Doc(
-                """
-                Configuration passed to Pydantic to exclude certain fields in the
-                response data.
-
-                Read more about it in the
-                [FastAPI docs for Response Model - Return Type](https://fastapi.tiangolo.com/tutorial/response-model/#response_model_include-and-response_model_exclude).
-                """
-            ),
-        ] = None,
-        response_model_by_alias: Annotated[
-            bool,
-            Doc(
-                """
-                Configuration passed to Pydantic to define if the response model
-                should be serialized by alias when an alias is used.
-
-                Read more about it in the
-                [FastAPI docs for Response Model - Return Type](https://fastapi.tiangolo.com/tutorial/response-model/#response_model_include-and-response_model_exclude).
-                """
-            ),
-        ] = True,
-        response_model_exclude_unset: Annotated[
-            bool,
-            Doc(
-                """
-                Configuration passed to Pydantic to define if the response data
-                should have all the fields, including the ones that were not set and
-                have their default values. This is different from
-                `response_model_exclude_defaults` in that if the fields are set,
-                they will be included in the response, even if the value is the same
-                as the default.
-
-                When `True`, default values are omitted from the response.
-
-                Read more about it in the
-                [FastAPI docs for Response Model - Return Type](https://fastapi.tiangolo.com/tutorial/response-model/#use-the-response_model_exclude_unset-parameter).
-                """
-            ),
-        ] = False,
-        response_model_exclude_defaults: Annotated[
-            bool,
-            Doc(
-                """
-                Configuration passed to Pydantic to define if the response data
-                should have all the fields, including the ones that have the same value
-                as the default. This is different from `response_model_exclude_unset`
-                in that if the fields are set but contain the same default values,
-                they will be excluded from the response.
-
-                When `True`, default values are omitted from the response.
-
-                Read more about it in the
-                [FastAPI docs for Response Model - Return Type](https://fastapi.tiangolo.com/tutorial/response-model/#use-the-response_model_exclude_unset-parameter).
-                """
-            ),
-        ] = False,
-        response_model_exclude_none: Annotated[
-            bool,
-            Doc(
-                """
-                Configuration passed to Pydantic to define if the response data should
-                exclude fields set to `None`.
-
-                This is much simpler (less smart) than `response_model_exclude_unset`
-                and `response_model_exclude_defaults`. You probably want to use one of
-                those two instead of this one, as those allow returning `None` values
-                when it makes sense.
-
-                Read more about it in the
-                [FastAPI docs for Response Model - Return Type](https://fastapi.tiangolo.com/tutorial/response-model/#response_model_exclude_none).
-                """
-            ),
-        ] = False,
         include_in_schema: Annotated[
             bool,
             Doc(
@@ -1662,7 +1295,7 @@ class AirRouter(RouterMixin):
 
             decorated = self._router.patch(
                 path,
-                response_model=response_model,
+                response_model=None,
                 status_code=status_code,
                 tags=tags,
                 dependencies=dependencies,
@@ -1672,12 +1305,12 @@ class AirRouter(RouterMixin):
                 responses=responses,
                 deprecated=deprecated,
                 operation_id=operation_id,
-                response_model_include=response_model_include,
-                response_model_exclude=response_model_exclude,
-                response_model_by_alias=response_model_by_alias,
-                response_model_exclude_unset=response_model_exclude_unset,
-                response_model_exclude_defaults=response_model_exclude_defaults,
-                response_model_exclude_none=response_model_exclude_none,
+                response_model_include=None,
+                response_model_exclude=None,
+                response_model_by_alias=True,
+                response_model_exclude_unset=False,
+                response_model_exclude_defaults=False,
+                response_model_exclude_none=False,
                 include_in_schema=include_in_schema,
                 response_class=response_class,
                 name=name,
@@ -1704,40 +1337,6 @@ class AirRouter(RouterMixin):
             ),
         ],
         *,
-        response_model: Annotated[
-            Any,
-            Doc(
-                """
-                The type to use for the response.
-
-                It could be any valid Pydantic *field* type. So, it doesn't have to
-                be a Pydantic model, it could be other things, like a `list`, `dict`,
-                etc.
-
-                It will be used for:
-
-                * Documentation: the generated OpenAPI (and the UI at `/docs`) will
-                    show it as the response (JSON Schema).
-                * Serialization: you could return an arbitrary object and the
-                    `response_model` would be used to serialize that object into the
-                    corresponding JSON.
-                * Filtering: the JSON sent to the client will only contain the data
-                    (fields) defined in the `response_model`. If you returned an object
-                    that contains an attribute `password` but the `response_model` does
-                    not include that field, the JSON sent to the client would not have
-                    that `password`.
-                * Validation: whatever you return will be serialized with the
-                    `response_model`, converting any data as necessary to generate the
-                    corresponding JSON. But if the data in the object returned is not
-                    valid, that would mean a violation of the contract with the client,
-                    so it's an error from the API developer. So, FastAPI will raise an
-                    error and return a 500 error code (Internal Server Error).
-
-                Read more about it in the
-                [FastAPI docs for Response Model](https://fastapi.tiangolo.com/tutorial/response-model/).
-                """
-            ),
-        ] = None,
         status_code: Annotated[
             int | None,
             Doc(
@@ -1857,94 +1456,6 @@ class AirRouter(RouterMixin):
                 """
             ),
         ] = None,
-        response_model_include: Annotated[
-            IncEx | None,
-            Doc(
-                """
-                Configuration passed to Pydantic to include only certain fields in the
-                response data.
-
-                Read more about it in the
-                [FastAPI docs for Response Model - Return Type](https://fastapi.tiangolo.com/tutorial/response-model/#response_model_include-and-response_model_exclude).
-                """
-            ),
-        ] = None,
-        response_model_exclude: Annotated[
-            IncEx | None,
-            Doc(
-                """
-                Configuration passed to Pydantic to exclude certain fields in the
-                response data.
-
-                Read more about it in the
-                [FastAPI docs for Response Model - Return Type](https://fastapi.tiangolo.com/tutorial/response-model/#response_model_include-and-response_model_exclude).
-                """
-            ),
-        ] = None,
-        response_model_by_alias: Annotated[
-            bool,
-            Doc(
-                """
-                Configuration passed to Pydantic to define if the response model
-                should be serialized by alias when an alias is used.
-
-                Read more about it in the
-                [FastAPI docs for Response Model - Return Type](https://fastapi.tiangolo.com/tutorial/response-model/#response_model_include-and-response_model_exclude).
-                """
-            ),
-        ] = True,
-        response_model_exclude_unset: Annotated[
-            bool,
-            Doc(
-                """
-                Configuration passed to Pydantic to define if the response data
-                should have all the fields, including the ones that were not set and
-                have their default values. This is different from
-                `response_model_exclude_defaults` in that if the fields are set,
-                they will be included in the response, even if the value is the same
-                as the default.
-
-                When `True`, default values are omitted from the response.
-
-                Read more about it in the
-                [FastAPI docs for Response Model - Return Type](https://fastapi.tiangolo.com/tutorial/response-model/#use-the-response_model_exclude_unset-parameter).
-                """
-            ),
-        ] = False,
-        response_model_exclude_defaults: Annotated[
-            bool,
-            Doc(
-                """
-                Configuration passed to Pydantic to define if the response data
-                should have all the fields, including the ones that have the same value
-                as the default. This is different from `response_model_exclude_unset`
-                in that if the fields are set but contain the same default values,
-                they will be excluded from the response.
-
-                When `True`, default values are omitted from the response.
-
-                Read more about it in the
-                [FastAPI docs for Response Model - Return Type](https://fastapi.tiangolo.com/tutorial/response-model/#use-the-response_model_exclude_unset-parameter).
-                """
-            ),
-        ] = False,
-        response_model_exclude_none: Annotated[
-            bool,
-            Doc(
-                """
-                Configuration passed to Pydantic to define if the response data should
-                exclude fields set to `None`.
-
-                This is much simpler (less smart) than `response_model_exclude_unset`
-                and `response_model_exclude_defaults`. You probably want to use one of
-                those two instead of this one, as those allow returning `None` values
-                when it makes sense.
-
-                Read more about it in the
-                [FastAPI docs for Response Model - Return Type](https://fastapi.tiangolo.com/tutorial/response-model/#response_model_exclude_none).
-                """
-            ),
-        ] = False,
         include_in_schema: Annotated[
             bool,
             Doc(
@@ -2042,7 +1553,7 @@ class AirRouter(RouterMixin):
 
             decorated = self._router.put(
                 path,
-                response_model=response_model,
+                response_model=None,
                 status_code=status_code,
                 tags=tags,
                 dependencies=dependencies,
@@ -2052,12 +1563,12 @@ class AirRouter(RouterMixin):
                 responses=responses,
                 deprecated=deprecated,
                 operation_id=operation_id,
-                response_model_include=response_model_include,
-                response_model_exclude=response_model_exclude,
-                response_model_by_alias=response_model_by_alias,
-                response_model_exclude_unset=response_model_exclude_unset,
-                response_model_exclude_defaults=response_model_exclude_defaults,
-                response_model_exclude_none=response_model_exclude_none,
+                response_model_include=None,
+                response_model_exclude=None,
+                response_model_by_alias=True,
+                response_model_exclude_unset=False,
+                response_model_exclude_defaults=False,
+                response_model_exclude_none=False,
                 include_in_schema=include_in_schema,
                 response_class=response_class,
                 name=name,
@@ -2084,40 +1595,6 @@ class AirRouter(RouterMixin):
             ),
         ],
         *,
-        response_model: Annotated[
-            Any,
-            Doc(
-                """
-                The type to use for the response.
-
-                It could be any valid Pydantic *field* type. So, it doesn't have to
-                be a Pydantic model, it could be other things, like a `list`, `dict`,
-                etc.
-
-                It will be used for:
-
-                * Documentation: the generated OpenAPI (and the UI at `/docs`) will
-                    show it as the response (JSON Schema).
-                * Serialization: you could return an arbitrary object and the
-                    `response_model` would be used to serialize that object into the
-                    corresponding JSON.
-                * Filtering: the JSON sent to the client will only contain the data
-                    (fields) defined in the `response_model`. If you returned an object
-                    that contains an attribute `password` but the `response_model` does
-                    not include that field, the JSON sent to the client would not have
-                    that `password`.
-                * Validation: whatever you return will be serialized with the
-                    `response_model`, converting any data as necessary to generate the
-                    corresponding JSON. But if the data in the object returned is not
-                    valid, that would mean a violation of the contract with the client,
-                    so it's an error from the API developer. So, FastAPI will raise an
-                    error and return a 500 error code (Internal Server Error).
-
-                Read more about it in the
-                [FastAPI docs for Response Model](https://fastapi.tiangolo.com/tutorial/response-model/).
-                """
-            ),
-        ] = None,
         status_code: Annotated[
             int | None,
             Doc(
@@ -2237,94 +1714,6 @@ class AirRouter(RouterMixin):
                 """
             ),
         ] = None,
-        response_model_include: Annotated[
-            IncEx | None,
-            Doc(
-                """
-                Configuration passed to Pydantic to include only certain fields in the
-                response data.
-
-                Read more about it in the
-                [FastAPI docs for Response Model - Return Type](https://fastapi.tiangolo.com/tutorial/response-model/#response_model_include-and-response_model_exclude).
-                """
-            ),
-        ] = None,
-        response_model_exclude: Annotated[
-            IncEx | None,
-            Doc(
-                """
-                Configuration passed to Pydantic to exclude certain fields in the
-                response data.
-
-                Read more about it in the
-                [FastAPI docs for Response Model - Return Type](https://fastapi.tiangolo.com/tutorial/response-model/#response_model_include-and-response_model_exclude).
-                """
-            ),
-        ] = None,
-        response_model_by_alias: Annotated[
-            bool,
-            Doc(
-                """
-                Configuration passed to Pydantic to define if the response model
-                should be serialized by alias when an alias is used.
-
-                Read more about it in the
-                [FastAPI docs for Response Model - Return Type](https://fastapi.tiangolo.com/tutorial/response-model/#response_model_include-and-response_model_exclude).
-                """
-            ),
-        ] = True,
-        response_model_exclude_unset: Annotated[
-            bool,
-            Doc(
-                """
-                Configuration passed to Pydantic to define if the response data
-                should have all the fields, including the ones that were not set and
-                have their default values. This is different from
-                `response_model_exclude_defaults` in that if the fields are set,
-                they will be included in the response, even if the value is the same
-                as the default.
-
-                When `True`, default values are omitted from the response.
-
-                Read more about it in the
-                [FastAPI docs for Response Model - Return Type](https://fastapi.tiangolo.com/tutorial/response-model/#use-the-response_model_exclude_unset-parameter).
-                """
-            ),
-        ] = False,
-        response_model_exclude_defaults: Annotated[
-            bool,
-            Doc(
-                """
-                Configuration passed to Pydantic to define if the response data
-                should have all the fields, including the ones that have the same value
-                as the default. This is different from `response_model_exclude_unset`
-                in that if the fields are set but contain the same default values,
-                they will be excluded from the response.
-
-                When `True`, default values are omitted from the response.
-
-                Read more about it in the
-                [FastAPI docs for Response Model - Return Type](https://fastapi.tiangolo.com/tutorial/response-model/#use-the-response_model_exclude_unset-parameter).
-                """
-            ),
-        ] = False,
-        response_model_exclude_none: Annotated[
-            bool,
-            Doc(
-                """
-                Configuration passed to Pydantic to define if the response data should
-                exclude fields set to `None`.
-
-                This is much simpler (less smart) than `response_model_exclude_unset`
-                and `response_model_exclude_defaults`. You probably want to use one of
-                those two instead of this one, as those allow returning `None` values
-                when it makes sense.
-
-                Read more about it in the
-                [FastAPI docs for Response Model - Return Type](https://fastapi.tiangolo.com/tutorial/response-model/#response_model_exclude_none).
-                """
-            ),
-        ] = False,
         include_in_schema: Annotated[
             bool,
             Doc(
@@ -2422,7 +1811,7 @@ class AirRouter(RouterMixin):
 
             decorated = self._router.delete(
                 path,
-                response_model=response_model,
+                response_model=None,
                 status_code=status_code,
                 tags=tags,
                 dependencies=dependencies,
@@ -2432,12 +1821,12 @@ class AirRouter(RouterMixin):
                 responses=responses,
                 deprecated=deprecated,
                 operation_id=operation_id,
-                response_model_include=response_model_include,
-                response_model_exclude=response_model_exclude,
-                response_model_by_alias=response_model_by_alias,
-                response_model_exclude_unset=response_model_exclude_unset,
-                response_model_exclude_defaults=response_model_exclude_defaults,
-                response_model_exclude_none=response_model_exclude_none,
+                response_model_include=None,
+                response_model_exclude=None,
+                response_model_by_alias=True,
+                response_model_exclude_unset=False,
+                response_model_exclude_defaults=False,
+                response_model_exclude_none=False,
                 include_in_schema=include_in_schema,
                 response_class=response_class,
                 name=name,


### PR DESCRIPTION
Now that `air.AirRouter` is built with composition, we can match the HTTP method arguments with those of `air.Air`. This PR does just that, removing response controllers which make sense for FastAPI but just serve as noise in an Air app.

# Issue(s)

#732

## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] **Bugfix**
- [x] **New feature**
  - [x] **Core Air** (Air Tags, Request/Response cycle, etc)
  - [ ] **Optional** (Authentication, CSRF, etc)
  - [ ] **Third-Party Integrated** (Cookbook documentation on using Air databases or a task manager, etc)
  - [ ] **Out-of-Scope** (Formal integration with databases, external task managers, or commercial services etc - won't be accepted, please create a separate project)
- [ ] **Refactoring** (no functional changes, no api changes)
- [ ] **Chore**: Dependency updates, Python version changes, etc.
- [ ] **Build related changes**
- [ ] **Documentation content changes**
- [ ] **Other** (please describe):

## Pull request tasks

The following have been completed for this task:

- [x] **Code changes**
- [ ] **Documentation changes for new or changed features**
- [ ] **Alterations of behavior come with a working implementation in the `examples` folder**
- [ ] **Tests on new or altered behaviors**

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] **I have run `just test` and `just qa`, ensuring my code changes passes all existing tests**
- [x] **I have performed a self-review of my own code**
- [x] **I have ensured that there are tests to cover my changes**
