### PR TITLE
chore: update Renovate config to disable `separateMajorMinor`

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -7,6 +7,7 @@
   dependencyDashboard: true,
   configMigration: true,
   updatePinnedDependencies: true,
+  separateMajorMinor: false,
   extends: [
     "config:best-practices",
     "helpers:pinGitHubActionDigestsToSemver",


### PR DESCRIPTION
This pull request introduces a configuration change to the Renovate bot settings. The update disables the separation of major and minor dependency updates, which means Renovate will group these updates together rather than creating separate pull requests for each.

- Renovate configuration update:
  * [`.github/renovate.json5`](diffhunk://#diff-20ab1190d08a53a3012bc191ed56205c8f0ffb8fa1715e9d36ecfd1d2ea8a790R10): Added `"separateMajorMinor": false` to group major and minor dependency updates into single pull requests instead of separating them.