### PR TITLE
chore: set `persist-credentials` to true in latest-changes workflow

### DIFF
--- a/.github/workflows/latest-changes.yaml
+++ b/.github/workflows/latest-changes.yaml
@@ -7,6 +7,9 @@ on:
     types:
       - closed
 
+permissions:
+  contents: write
+
 jobs:
   latest-changes:
     runs-on: ubuntu-latest
@@ -22,6 +25,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
+          # Required for git push (CHANGELOG.md)
           persist-credentials: true # zizmor: ignore[artipacked]
       - uses: tiangolo/latest-changes@c9d329cb147f0ddf4fb631214e3f838ff17ccbbd # 0.4.1
         with:


### PR DESCRIPTION
This pull request makes a small change to the workflow configuration by updating the `persist-credentials` setting for the `actions/checkout` step.

* Set `persist-credentials` to `true` in the `.github/workflows/latest-changes.yaml` workflow file, allowing credentials to persist for subsequent steps.