### PR TITLE
CI: disable scheduled Dependabot version updates 

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+# .github/dependabot.yml
+version: 2
+
+# Intentionally empty: this disables all scheduled Dependabot "version update" PRs
+# (the regular dependency bump PRs).
+updates: []
+
+# Note:
+# Security update PRs are controlled by repo/org settings, not by entries here.
+# Keep "Dependabot alerts" and "Dependabot security updates" enabled in Settings.


### PR DESCRIPTION
This pull request disables all scheduled Dependabot version update pull requests by adding an intentionally empty `.github/dependabot.yml` file. Security update PRs are not affected and will continue to be managed via repository or organization settings.

- Dependabot configuration:
  * Added `.github/dependabot.yml` with an empty `updates` list to disable scheduled version update PRs.