### PR TITLE
Disable automerge in Renovate config

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -13,8 +13,8 @@
   extends: [
     "config:best-practices",
     "helpers:pinGitHubActionDigestsToSemver",
-    // Automerge only after all required GitHub status checks pass
-    ":automergeAll",
+    // Disable automerging feature - wait for humans to merge all PRs.
+    ":automergeDisabled",
     ":automergePr",
     ":automergeRequireAllStatusChecks",
     // conventional commits


### PR DESCRIPTION
This pull request makes a small configuration change to the Renovate bot settings. The automerge feature is now explicitly disabled, so pull requests will wait for human approval before merging.

* Disabled Renovate's automerge feature by replacing `:automergeAll` with `:automergeDisabled` in `.github/renovate.json5`.