### PR TITLE
CI: smoke-test wheel and sdist in `.github/workflows/release-to-pypi.yaml` 

### DIFF
--- a/.github/workflows/release-to-pypi.yaml
+++ b/.github/workflows/release-to-pypi.yaml
@@ -1,4 +1,11 @@
-# .github/workflows/publish-on-tag.yml
+# .github/workflows/release-to-pypi.yaml
+# https://docs.astral.sh/uv/guides/package/#building-and-publishing-a-package
+# https://docs.astral.sh/uv/guides/integration/github/#publishing-to-pypi
+
+# TODO -> Trusted Publishing + publish attestations:
+# 1. https://docs.pypi.org/trusted-publishers/adding-a-publisher
+# 2. https://github.com/astral-sh/attest-action/blob/main/README.md
+
 name: Publish Python Package with uv
 
 permissions:
@@ -8,6 +15,19 @@ on:
   push:
     tags:
       - "v*" # Triggers on tags like v1.0.0
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.workflow_run.id }}
+  cancel-in-progress: true
+
+env:
+  COLUMNS: 150
+  CI: 1
+  FORCE_COLOR: 1
+  JUST_COLOR: always
+  JUST_COMMAND_COLOR: purple
+  JUST_EXPLAIN: true
+  JUST_HIGHLIGHT: true
 
 jobs:
   publish:
@@ -19,7 +39,6 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
-
       - name: Set up uv
         uses: astral-sh/setup-uv@61cb8a9741eeb8a550a1b8544337180c0fc8476b # v7.2.0
         with:
@@ -30,16 +49,22 @@ jobs:
             uv.lock
             pyproject.toml
             .python-version
-
+      - name: Install just
+        uses: taiki-e/install-action@710817a1645ef40daad5bcde7431ceccf6cc3528 # 2.67.13
+        with:
+          tool: just
       - name: Build with uv
-        run: uv build
-
+        run: just build
+      - name: Smoke test (wheel)
+        run: just test-smoke-on-wheel
+      - name: Smoke test (source distribution)
+        run: just test-smoke-on-source-distribution
       - name: Publish with uv
         env:
           UV_PYPI_TOKEN: ${{ secrets.PYPI_API_TOKEN }}
         run: uv publish --token "$UV_PYPI_TOKEN"
 
-      - name: Run latest-tag
+      - name: Set the latest tag
         uses: EndBug/latest-tag@cce4de6d46f34a17b99785d5574a351f4289fd59 # latest
         with:
           # You can change the name of the tag or branch with this input.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -159,6 +159,7 @@ test = [
     "pytest-env==1.2.0", # https://pypi.org/project/pytest-env
     "pytest-github-actions-annotate-failures==0.3.0", # https://pypi.org/project/pytest-github-actions-annotate-failures
     "pytest-pretty==1.3.0", # https://pypi.org/project/pytest-pretty
+    "pytest-smoke==0.10.0", # https://pypi.org/project/pytest-smoke
 ]
 
 # endregion dependencies

--- a/uv.lock
+++ b/uv.lock
@@ -56,6 +56,7 @@ dev = [
     { name = "pytest-env" },
     { name = "pytest-github-actions-annotate-failures" },
     { name = "pytest-pretty" },
+    { name = "pytest-smoke" },
     { name = "ruff" },
     { name = "rumdl" },
     { name = "shellcheck-py" },
@@ -109,6 +110,7 @@ test = [
     { name = "pytest-env" },
     { name = "pytest-github-actions-annotate-failures" },
     { name = "pytest-pretty" },
+    { name = "pytest-smoke" },
 ]
 
 [package.metadata]
@@ -159,6 +161,7 @@ dev = [
     { name = "pytest-env", specifier = "==1.2.0" },
     { name = "pytest-github-actions-annotate-failures", specifier = "==0.3.0" },
     { name = "pytest-pretty", specifier = "==1.3.0" },
+    { name = "pytest-smoke", specifier = ">=0.10.0" },
     { name = "ruff", specifier = "==0.14.14" },
     { name = "rumdl", specifier = "==0.1.1" },
     { name = "shellcheck-py", specifier = "==0.11.0.1" },
@@ -213,6 +216,7 @@ test = [
     { name = "pytest-env", specifier = "==1.2.0" },
     { name = "pytest-github-actions-annotate-failures", specifier = "==0.3.0" },
     { name = "pytest-pretty", specifier = "==1.3.0" },
+    { name = "pytest-smoke", specifier = ">=0.10.0" },
 ]
 
 [[package]]
@@ -2180,6 +2184,19 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/ba/d7/c699e0be5401fe9ccad484562f0af9350b4e48c05acf39fb3dab1932128f/pytest_pretty-1.3.0.tar.gz", hash = "sha256:97e9921be40f003e40ae78db078d4a0c1ea42bf73418097b5077970c2cc43bf3", size = 219297, upload-time = "2025-06-04T12:54:37.322Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ab/85/2f97a1b65178b0f11c9c77c35417a4cc5b99a80db90dad4734a129844ea5/pytest_pretty-1.3.0-py3-none-any.whl", hash = "sha256:074b9d5783cef9571494543de07e768a4dda92a3e85118d6c7458c67297159b7", size = 5620, upload-time = "2025-06-04T12:54:36.229Z" },
+]
+
+[[package]]
+name = "pytest-smoke"
+version = "0.10.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pluggy" },
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/61/99/1ea4d28b921ff1545ff6daa67b5ca7caa7ce271fa93b4f3b5ad9fde71b48/pytest_smoke-0.10.0.tar.gz", hash = "sha256:762d9226fabe26306e0cb39a43c3ea04359c365352fff500acaf99f338f2bfaa", size = 29574, upload-time = "2025-11-09T19:06:09.831Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cc/e4/39a92a0268e10a95b50348f3929b3f15b3400e7eca4851961b19a4443c16/pytest_smoke-0.10.0-py3-none-any.whl", hash = "sha256:54a42ee7025842ea094909f0ac04cf2eff2b2f82f7362e5276c3afc52e837d64", size = 16568, upload-time = "2025-11-09T19:06:08.247Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
This pull request enhances the Python package release workflow and improves build and test automation. The main changes include updating the GitHub Actions workflow for publishing to PyPI, expanding `justfile` automation with new build and test recipes, and introducing smoke testing for distribution artifacts.

**Release workflow improvements:**
- Updated `.github/workflows/release-to-pypi.yaml` to enable caching for `uv`, add environment variables, and use `just` for building and testing. The workflow now runs smoke tests on both wheel and source distributions before publishing, and sets the latest tag after release. [[1]](diffhunk://#diff-d5e120db03b1879bb04ae3e8268c02be43ecbe752e440c2e40714155e0306e09L1-R8) [[2]](diffhunk://#diff-d5e120db03b1879bb04ae3e8268c02be43ecbe752e440c2e40714155e0306e09R19-R31) [[3]](diffhunk://#diff-d5e120db03b1879bb04ae3e8268c02be43ecbe752e440c2e40714155e0306e09L22-R67)

**Build and version automation:**
- Refactored `justfile` to use `uv version --short` for version detection, added a `bump-version` recipe, and improved build recipes with support for building all packages and force-cleaning build directories. Tagging now uses the detected project version. [[1]](diffhunk://#diff-deb9bb56fb122db0b605aa5b63f95a4665c905b18dd670e1fa6c877576a94ff1L29-L30) [[2]](diffhunk://#diff-deb9bb56fb122db0b605aa5b63f95a4665c905b18dd670e1fa6c877576a94ff1R40) [[3]](diffhunk://#diff-deb9bb56fb122db0b605aa5b63f95a4665c905b18dd670e1fa6c877576a94ff1R219-R230) [[4]](diffhunk://#diff-deb9bb56fb122db0b605aa5b63f95a4665c905b18dd670e1fa6c877576a94ff1L493-R557)

**Testing enhancements:**
- Added new `justfile` recipes for running smoke tests on the built wheel and source distribution using isolated environments, and integrated the `pytest-smoke` plugin for lightweight verification. [[1]](diffhunk://#diff-deb9bb56fb122db0b605aa5b63f95a4665c905b18dd670e1fa6c877576a94ff1R169-R189) [[2]](diffhunk://#diff-deb9bb56fb122db0b605aa5b63f95a4665c905b18dd670e1fa6c877576a94ff1R436-R450) [[3]](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711R162)