### PR TITLE
CI: Fix concurrency group to use `${{ github.ref }}` in `.github/workflows/release-to-pypi.yaml`

### DIFF
--- a/.github/workflows/release-to-pypi.yaml
+++ b/.github/workflows/release-to-pypi.yaml
@@ -17,7 +17,7 @@ on:
       - "v*" # Triggers on tags like v1.0.0
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.workflow_run.id }}
+  group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
 env:


### PR DESCRIPTION
This pull request makes a small update to the workflow concurrency configuration in `.github/workflows/release-to-pypi.yaml`. The change improves how concurrent workflow runs are grouped and managed.

- Changed the `concurrency.group` value to use `github.ref` instead of `github.event.workflow_run.id`, ensuring that concurrent runs are grouped by the Git reference (branch or tag) rather than a workflow run ID.