### PR TITLE
Standardize argument handling and quoting in `justfile`

### DIFF
--- a/justfile
+++ b/justfile
@@ -78,7 +78,7 @@ PROJECT_VERSION := `uv version --short`
 [private]
 [positional-arguments]
 @run-each RECIPE +ARGS:
-    for ARG in "$@"; do just "{{ RECIPE }}" "$ARG"; done
+    for ARG in "${@:2}"; do just "{{ RECIPE }}" "$ARG"; done
 
 # Run RECIPE only when ENABLED is set
 [doc]
@@ -184,7 +184,7 @@ renovate-config-validator:
 [arg("ARGS", help="Extra Args for uv run")]
 [positional-arguments]
 run-on-build WITH_WHEEL="" WITH_SOURCE_DISTRIBUTION="" *ARGS:
-    uv run --isolated --no-project --with "{{ WITH_WHEEL || WITH_SOURCE_DISTRIBUTION }}" "$@"
+    uv run --isolated --no-project --with "{{ WITH_WHEEL || WITH_SOURCE_DISTRIBUTION }}" "${@:3}"
 
 # Run isolated `uv run` using the wheel from `dist/`
 [group('uv')]
@@ -434,8 +434,8 @@ test-on PY_VERSION:
 [group('test')]
 [positional-arguments]
 pdb MAXFAIL="10" *ARGS:
-    @echo "Running with arg: $*"
-    just run -- pytest --pdb --maxfail="{{ MAXFAIL }}" "$@"
+    @echo "Running with arg: ${*:2}"
+    just run -- pytest --pdb --maxfail="{{ MAXFAIL }}" "${@:2}"
 
 # TDD mode: stop at the first test failure
 [group('test')]


### PR DESCRIPTION
This pull request makes several small but important fixes to how positional arguments are handled in the `justfile` command recipes. The changes ensure that arguments are correctly passed to subcommands, which improves script reliability and correctness.

Argument handling improvements:

* Updated the `@run-each` recipe to correctly forward only the arguments after the recipe name by using `"${@:2}"` instead of `"$@"`.
* Modified the `run-on-build` recipe to pass extra arguments starting from the third argument with `"${@:3}"`, ensuring that only user-supplied arguments are forwarded.
* Changed the `pdb` recipe to echo and pass arguments starting from the second position with `"${*:2}"` and `"${@:2}"`, preventing accidental inclusion of internal parameters.