### PR TITLE
Deploy docs via GitHub Pages API instead of git push

### DIFF
--- a/.github/workflows/publish-docs.yaml
+++ b/.github/workflows/publish-docs.yaml
@@ -5,26 +5,22 @@ on:
       - main
 
 permissions:
-  contents: write
+  contents: read
 
 jobs:
-  deploy:
+  build:
     if: >-
       github.actor != 'dependabot[bot]' &&
       github.actor != 'renovate[bot]' &&
       github.actor != 'renovate'
-    name: Deploy docs
+    name: Build docs
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
-          persist-credentials: true
-      - name: Configure Git Credentials
-        run: |
-          git config user.name github-actions[bot]
-          git config user.email 41898282+github-actions[bot]@users.noreply.github.com
+          persist-credentials: false
       - name: Set cache identifier
         run: printf 'cache_id=%s\n' "$(date -u '+%V')" >> "$GITHUB_ENV"
       - name: Cache MkDocs assets
@@ -39,9 +35,24 @@ jobs:
         with:
           enable-cache: true
           cache-dependency-glob: uv.lock
-      - name: Install just
-        uses: taiki-e/install-action@650c5ca14212efbbf3e580844b04bdccf68dac31 # 2.67.18
+      - name: Build documentation
+        run: uv run mkdocs build --strict
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@7b1f4a764d45c48632c6b24a0339c27f5614fb0b # v4.0.0
         with:
-          tool: just
-      - name: Deploy the documentation to GitHub Pages
-        run: just doc-build
+          path: site/
+
+  deploy:
+    needs: build
+    name: Deploy docs
+    runs-on: ubuntu-latest
+    permissions:
+      pages: write
+      id-token: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e # v4.0.5


### PR DESCRIPTION
## Summary

- Replaces `mkdocs gh-deploy --force` with the official `actions/upload-pages-artifact` + `actions/deploy-pages` pipeline
- Sets `persist-credentials: false` (was `true`)
- Drops `permissions: contents: write` to `contents: read`
- Removes the "Configure Git Credentials" step (no longer needed)
- Removes `just` installation (no longer needed)

The workflow now builds the site with `uv run mkdocs build --strict`, uploads it as a Pages artifact, and deploys via the GitHub Pages API. No git credentials on disk, no write access to repo contents.

## Before merging

Change the repo's Pages source setting from "Deploy from a branch (gh-pages)" to "GitHub Actions":

**Settings > Pages > Source > GitHub Actions**

Or via API:
```
gh api repos/feldroy/air/pages -X PUT -f build_type=workflow
```

## Test plan

- [x] Switch Pages source to "GitHub Actions" in repo settings
- [x] Merge this PR
- [ ] Verify docs deploy successfully at https://docs.airwebframework.org/