### PR TITLE
Fix docstring mismatches that break mkdocs strict mode

### DIFF
--- a/src/air/applications.py
+++ b/src/air/applications.py
@@ -35,11 +35,8 @@ class Air(RouterMixin):
         dependencies: A list of global dependencies, they will be applied to each *path operation*,
                 including in sub-routers.
         middleware: List of middleware to be added when creating the application.
-        default_response_class: The default response class to be used.
         redirect_slashes: Whether to detect and redirect slashes in URLs when the client doesn't
                 use the same format.
-        on_startup: A list of startup event handler functions.
-        on_shutdown: A list of shutdown event handler functions.
         lifespan: A `Lifespan` context manager handler. This replaces `startup` and
                 `shutdown` functions with a single context manager.
         path_separator: An optional path separator, default to "-". valid option available ["/", "-"]

--- a/src/air/tags/models/stock.py
+++ b/src/air/tags/models/stock.py
@@ -1662,7 +1662,6 @@ class Meta(SelfClosingTag):
         name: Specifies a name for the metadata.
         class_: Substituted as the DOM `class` attribute.
         id_: DOM ID attribute.
-        style: Inline style attribute.
         custom_attributes: Keyword arguments transformed into tag attributes.
     """
 
@@ -1764,7 +1763,8 @@ class Object(BaseTag):
         children: Tags, strings, or other rendered content.
         archive: A space-separated list of URIs for archives of resources for the object.
         border: The width of a border around the object.
-        classidcodebase: The codebase URL for the object.
+        classid_: The class identifier for the object.
+        codebase: The base URL for the object.
         codetype: The content type of the code.
         data: The address of the object's data.
         declare: Declares the object without instantiating it.


### PR DESCRIPTION
## Summary

The publish-docs workflow now uses `mkdocs build --strict`, which treats warnings as errors. Three docstring/signature mismatches from the FastAPI port were causing the build to abort:

- **`applications.py`**: Docstring listed `default_response_class`, `on_startup`, `on_shutdown` but these params were intentionally omitted from Air's `__init__`
- **`stock.py` Meta**: Docstring listed `style` but `<meta>` tags don't take a style attribute, so it was correctly absent from the signature
- **`stock.py` Object**: Docstring had `classidcodebase` (one word) but the signature has separate `classid_` and `codebase` params

## Test plan

- [ ] Verify publish-docs workflow passes after merge
- [ ] Confirm docs deploy to https://docs.airwebframework.org/