### PR TITLE
Add dark mode logo variant for docs site

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -3,8 +3,8 @@
   <br>
   <a href="https://airwebframework.org">
     <picture>
-      <source srcset="https://raw.githubusercontent.com/feldroy/air/main/img/air-dark.svg" media="(prefers-color-scheme: dark)">
-      <source srcset="https://raw.githubusercontent.com/feldroy/air/main/img/air.svg" media="(prefers-color-scheme: light)">
+      <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/feldroy/air/main/img/air-dark.svg">
+      <source media="(prefers-color-scheme: light)" srcset="https://raw.githubusercontent.com/feldroy/air/main/img/air.svg">
       <img src="https://raw.githubusercontent.com/feldroy/air/main/img/air.svg" width="180" alt="Air">
     </picture>
   </a>


### PR DESCRIPTION
## Summary

- Use `<picture>` with `prefers-color-scheme` media queries to swap between `air.svg` (light) and `air-dark.svg` (dark), matching the README approach
- Addresses Copilot review on #1065

## Test plan

- [ ] Verify docs build with `uv run mkdocs build --strict`
- [ ] Check logo renders correctly in both light and dark mode