### PR TITLE
fix: runtime type checking for `AirResponse.render()`

### DIFF
--- a/src/air/responses.py
+++ b/src/air/responses.py
@@ -29,7 +29,12 @@ class AirResponse(HTMLResponse):
 
         Returns:
             Rendered HTML as bytes or memoryview.
+        Raises:
+            TypeError: If tag is neither a BaseTag nor a string.
         """
+        if not isinstance(tag, (BaseTag, str)):
+            msg = f"render() expected BaseTag or str, got {type(tag).__name__!r}"
+            raise TypeError(msg)
         return super().render(str(tag))
 
 

--- a/src/air/responses.py
+++ b/src/air/responses.py
@@ -24,15 +24,15 @@ class AirResponse(HTMLResponse):
     """Response class to handle air.tags.Tags or HTML (from Jinja2)."""
 
     @override
-    def render(self, tag: BaseTag | str) -> bytes | memoryview:  # ty: ignore[invalid-method-override]
+    def render(self, tag: BaseTag | str | None) -> bytes | memoryview:  # ty: ignore[invalid-method-override]
         """Render Tag elements to bytes of HTML.
 
         Returns:
             Rendered HTML as bytes or memoryview.
         Raises:
-            TypeError: If tag is neither a BaseTag nor a string.
+            TypeError: If tag (if not None) is neither a BaseTag nor a string.
         """
-        if not isinstance(tag, (BaseTag, str)):
+        if tag is not None and not isinstance(tag, (BaseTag, str)):
             msg = f"render() expected BaseTag or str, got {type(tag).__name__!r}"
             raise TypeError(msg)
         return super().render(str(tag))

--- a/src/air/responses.py
+++ b/src/air/responses.py
@@ -1,7 +1,7 @@
 """Air uses custom response classes to improve the developer experience."""
 
 from collections.abc import Mapping
-from typing import override
+from typing import Any, override
 
 from fastapi import status
 from starlette.background import BackgroundTask
@@ -24,18 +24,20 @@ class AirResponse(HTMLResponse):
     """Response class to handle air.tags.Tags or HTML (from Jinja2)."""
 
     @override
-    def render(self, tag: BaseTag | str | None) -> bytes | memoryview:  # ty: ignore[invalid-method-override]
+    def render(self, content: Any) -> bytes | memoryview:
         """Render Tag elements to bytes of HTML.
 
         Returns:
             Rendered HTML as bytes or memoryview.
         Raises:
-            TypeError: If tag (if not None) is neither a BaseTag nor a string.
+            TypeError: If content is neither a BaseTag, a string, nor None.
         """
-        if tag is not None and not isinstance(tag, (BaseTag, str)):
-            msg = f"render() expected BaseTag or str, got {type(tag).__name__!r}"
+        if content is not None and not isinstance(content, (BaseTag, str)):
+            msg = f"render() expected BaseTag or str, got {type(content).__name__!r}"
             raise TypeError(msg)
-        return super().render(str(tag))
+        if isinstance(content, BaseTag):
+            content = str(content)
+        return super().render(content)
 
 
 TagResponse = AirResponse

--- a/tests/test_applications.py
+++ b/tests/test_applications.py
@@ -560,8 +560,8 @@ def test_custom_response_class() -> None:
     class WrappingResponse(air.AirResponse):
         """Custom response that wraps content in an <article> tag."""
 
-        def render(self, tag: object) -> bytes:
-            return str(air.Article(tag)).encode()
+        def render(self, content: object) -> bytes:
+            return str(air.Article(content)).encode()
 
     @app.get("/custom", response_class=WrappingResponse)
     def custom_page() -> air.H1:

--- a/tests/test_responses.py
+++ b/tests/test_responses.py
@@ -13,7 +13,7 @@ from .utils import clean_doc
 
 class CustomLayoutResponse(air.AirResponse):
     @override
-    def render(self, tag: BaseTag | str) -> bytes | memoryview:
+    def render(self, tag: BaseTag | str | None) -> bytes | memoryview:
         return super().render(air.Html(air.Body(tag)))
 
 

--- a/tests/test_responses.py
+++ b/tests/test_responses.py
@@ -1,11 +1,12 @@
 from collections.abc import AsyncGenerator
-from typing import override
+from typing import Any, override
 
+import pytest
 from fastapi import status
 from fastapi.testclient import TestClient
 
 import air
-from air import H1, AirResponse, Article, BaseTag, Div, Html, Main
+from air import H1, AirResponse, Article, Div, Html, Main
 from air.responses import TagResponse
 
 from .utils import clean_doc
@@ -13,8 +14,8 @@ from .utils import clean_doc
 
 class CustomLayoutResponse(air.AirResponse):
     @override
-    def render(self, tag: BaseTag | str | None) -> bytes | memoryview:
-        return super().render(air.Html(air.Body(tag)))
+    def render(self, content: Any) -> bytes | memoryview:
+        return super().render(air.Html(air.Body(content)))
 
 
 def test_tag_response_obj() -> None:
@@ -98,6 +99,20 @@ def test_air_response_type() -> None:
     assert (
         response.text == "<main><h1>Hello, clean HTML response!</h1><p>This is a paragraph in the response.</p></main>"
     )
+
+
+def test_air_response_without_content_is_empty() -> None:
+    response = air.AirResponse()
+
+    assert response.body == b""
+
+
+def test_air_response_rejects_unsupported_content() -> None:
+    with pytest.raises(
+        TypeError,
+        match=r"render\(\) expected BaseTag or str, got 'int'",
+    ):
+        air.AirResponse(42)
 
 
 def test_air_response_html() -> None:

--- a/tests/test_templating.py
+++ b/tests/test_templating.py
@@ -225,6 +225,21 @@ def test_renderer() -> None:
     assert response.text == "<!doctype html><html><title>Test Page</title><h1>Hello, World!</h1></html>"
 
 
+def test_render_rejects_non_str_or_basetag() -> None:
+    app = Air()
+
+    @app.page
+    def index() -> int:
+        return 42
+
+    client = TestClient(app)
+    with pytest.raises(
+        TypeError,
+        match=r"render\(\) expected BaseTag or str, got 'int'"
+    ):
+        client.get("/")
+
+
 def test_renderer_without_request_for_components() -> None:
     """Test the Renderer class."""
     app = air.Air()

--- a/tests/test_templating.py
+++ b/tests/test_templating.py
@@ -233,10 +233,7 @@ def test_render_rejects_non_str_or_basetag() -> None:
         return 42
 
     client = TestClient(app)
-    with pytest.raises(
-        TypeError,
-        match=r"render\(\) expected BaseTag or str, got 'int'"
-    ):
+    with pytest.raises(TypeError, match=r"render\(\) expected BaseTag or str, got 'int'"):
         client.get("/")
 
 

--- a/tests/test_templating.py
+++ b/tests/test_templating.py
@@ -225,18 +225,6 @@ def test_renderer() -> None:
     assert response.text == "<!doctype html><html><title>Test Page</title><h1>Hello, World!</h1></html>"
 
 
-def test_render_rejects_non_str_or_basetag() -> None:
-    app = Air()
-
-    @app.page
-    def index() -> int:
-        return 42
-
-    client = TestClient(app)
-    with pytest.raises(TypeError, match=r"render\(\) expected BaseTag or str, got 'int'"):
-        client.get("/")
-
-
 def test_renderer_without_request_for_components() -> None:
     """Test the Renderer class."""
     app = air.Air()


### PR DESCRIPTION
<!--
Before submitting:
- Read CONTRIBUTING.md for workflow
- Read AGENTS.md for architecture (especially if AI-generated)

Air's design principles: semantic APIs with clear docstrings,
concise docs mindful of context window sizes, max readability,
less code is better, zero config is ideal. — airwebframework.org
-->

## What

This PR implements runtime type checking for `AirResponse.render()`, which accepts a `tag` annotated as `BaseTag | str | None`.

Fixes issue #1075 

## Pattern

I followed similar patterns in `test_templating.py` for the unit tests.

## Reviewer Focus

Since `tag`'s type annotation wasn't being checked at runtime, there are code paths where `None` could possibly be passed, which seems to be handled in `Response.render` but doesn't seem to be acknowledged in `AirResponse.render`. Was wondering if this was intentional or a silent bug.

## Checklist

- [x] Diff contains only changes for this task — no unrelated refactoring or cleanup
- [x] Addresses exactly one issue or feature
- [x] New or changed behavior has test coverage
- [x] This is the simplest viable approach
- [x] AI provenance section removed or accurate
