### PR TITLE
fix: filter fastapi-only params

### DIFF
--- a/src/air/applications.py
+++ b/src/air/applications.py
@@ -270,6 +270,13 @@ class Air(RouterMixin):
         This preserves most FastAPI initialization parameters while setting:
             - AirResponse as the default response class.
             - AirRoute as the default route class.
+
+        Raises:
+            ValueError: If fastapi_app is None and kwargs contain parameters
+                that should be passed via fastapi_app instead. These
+                parameters are: default_response_class, on_startup,
+                on_shutdown, docs_url, redoc_url, openapi_url,
+                webhooks, deprecated.
         """
         self.path_separator = path_separator
         if exception_handlers is None:
@@ -290,6 +297,22 @@ class Air(RouterMixin):
 
         # Create internal FastAPI instance
         if fastapi_app is None:
+            fastapi_kwargs_with_fixed_values = {
+                "default_response_class",
+                "on_startup",
+                "on_shutdown",
+                "docs_url",
+                "redoc_url",
+                "openapi_url",
+                "webhooks",
+                "deprecated",
+            }
+
+            if kwargs_supplied := extra.keys() & fastapi_kwargs_with_fixed_values:
+                kwargs_supplied_str = ", ".join(sorted(f"`{kwarg}`" for kwarg in kwargs_supplied))
+                msg = f"Use `fastapi_app` to pass {kwargs_supplied_str} instead."
+                raise ValueError(msg)
+
             self._app = FastAPI(
                 debug=debug,
                 routes=routes,

--- a/src/air/applications.py
+++ b/src/air/applications.py
@@ -23,6 +23,18 @@ from .exception_handlers import DEFAULT_EXCEPTION_HANDLERS, ExceptionHandlersTyp
 from .responses import AirResponse
 from .routing import AirRoute, AirRouter, RouterMixin
 
+# FastAPI arguments whose values Air deliberately controls.
+_FIXED_FASTAPI_KWARGS = frozenset({
+    "default_response_class",
+    "on_startup",
+    "on_shutdown",
+    "docs_url",
+    "redoc_url",
+    "openapi_url",
+    "webhooks",
+    "deprecated",
+})
+
 
 class Air(RouterMixin):
     """Air web framework - HTML-first web apps powered by FastAPI.
@@ -299,18 +311,10 @@ class Air(RouterMixin):
 
         # Create internal FastAPI instance
         if fastapi_app is None:
-            fastapi_kwargs_with_fixed_values = {
-                "default_response_class",
-                "on_startup",
-                "on_shutdown",
-                "docs_url",
-                "redoc_url",
-                "openapi_url",
-                "webhooks",
-                "deprecated",
-            }
-
-            if kwargs_supplied := extra.keys() & fastapi_kwargs_with_fixed_values:
+            # These arguments are set explicitly below. Catching duplicates here
+            # replaces FastAPI's confusing "multiple values" TypeError with the
+            # supported customization path.
+            if kwargs_supplied := extra.keys() & _FIXED_FASTAPI_KWARGS:
                 kwargs_supplied_str = ", ".join(sorted(f"`{kwarg}`" for kwarg in kwargs_supplied))
                 msg = f"Use `fastapi_app` to pass {kwargs_supplied_str} instead."
                 raise ValueError(msg)

--- a/tests/test_applications.py
+++ b/tests/test_applications.py
@@ -1,3 +1,4 @@
+import pytest
 from fastapi import Depends, FastAPI
 from fastapi.routing import APIRouter
 from fastapi.testclient import TestClient
@@ -24,6 +25,13 @@ def test_air_app_factory() -> None:
     assert response.status_code == 200
     assert response.headers["content-type"] == "text/html; charset=utf-8"
     assert response.text == "<h1>Hello, World!</h1>"
+
+
+def test_air_app_factory_rejects_fastapi_params() -> None:
+    # https://github.com/feldroy/air/issues/1073
+
+    with pytest.raises(ValueError, match=r"Use `fastapi_app` to pass `docs_url`, `redoc_url` instead."):
+        air.Air(docs_url="", redoc_url="")
 
 
 def test_air_plus_fastapi() -> None:

--- a/tests/test_applications.py
+++ b/tests/test_applications.py
@@ -27,11 +27,27 @@ def test_air_app_factory() -> None:
     assert response.text == "<h1>Hello, World!</h1>"
 
 
-def test_air_app_factory_rejects_fastapi_params() -> None:
+@pytest.mark.parametrize(
+    "parameter_name",
+    [
+        "default_response_class",
+        "on_startup",
+        "on_shutdown",
+        "docs_url",
+        "redoc_url",
+        "openapi_url",
+        "webhooks",
+        "deprecated",
+    ],
+)
+def test_air_app_factory_rejects_fixed_fastapi_params(parameter_name: str) -> None:
     # https://github.com/feldroy/air/issues/1073
 
-    with pytest.raises(ValueError, match=r"Use `fastapi_app` to pass `docs_url`, `redoc_url` instead."):
-        air.Air(docs_url="", redoc_url="")
+    with pytest.raises(
+        ValueError,
+        match=rf"Use `fastapi_app` to pass `{parameter_name}` instead\.",
+    ):
+        air.Air(**{parameter_name: None})
 
 
 def test_air_plus_fastapi() -> None:


### PR DESCRIPTION
<!--
Before submitting:
- Read CONTRIBUTING.md for workflow
- Read AGENTS.md for architecture (especially if AI-generated)

Air's design principles: semantic APIs with clear docstrings,
concise docs mindful of context window sizes, max readability,
less code is better, zero config is ideal. — airwebframework.org
-->

## What

I explicitly defined the kwargs we're passing with fixed values into `Air`'s internal `FastAPI` instance, and made the app factory raise a `ValueError` that points them to the `fastapi_app` route if they try to pass their own values instead.

Fixes issue #1073 

## Pattern

Followed the existing app factory pattern.

## Reviewer Focus

I don't think any special attention is required from the reviewers.

## Checklist

- [x] Diff contains only changes for this task — no unrelated refactoring or cleanup
- [x] Addresses exactly one issue or feature
- [x] New or changed behavior has test coverage
- [x] This is the simplest viable approach
- [x] AI provenance section removed or accurate
