### PR TITLE
AirForm maps semantic widgets to valid HTML and round-trips checkboxes

### DIFF
--- a/src/air/form/main.py
+++ b/src/air/form/main.py
@@ -88,17 +88,29 @@ def _is_optional(annotation: Any) -> bool:
 # ---------------------------------------------------------------------------
 
 
+_WIDGET_TO_HTML_TYPE: dict[str, str] = {
+    "toggle": "checkbox",
+    "slider": "range",
+    "phone": "tel",
+    "currency": "number",
+    "search": "search",
+    "rich_text": "textarea",
+    "code": "textarea",
+}
+
+
 def pydantic_type_to_html_type(field_info: Any) -> str:
     """Return HTML input type from a Pydantic field's type and metadata.
 
     Checks AirField metadata first (Widget, Choices), then infers
-    from the Python type annotation.
+    from the Python type annotation. Semantic widget names (toggle,
+    slider, etc.) are mapped to valid HTML input types.
     """
     meta = _meta_dict(field_info)
 
     widget = _get_meta(meta, Widget)
     if widget:
-        return widget.kind
+        return _WIDGET_TO_HTML_TYPE.get(widget.kind, widget.kind)
     if Choices in meta:
         return "select"
 
@@ -300,6 +312,10 @@ def default_form_widget(  # noqa: C901
                 sel = " selected" if value is not None and str(value) == opt_val else ""
                 parts.append(f'    <option value="{escape(opt_val)}"{sel}>{escape(opt_label)}</option>')
             parts.append("  </select>")
+
+        elif input_type == "checkbox":
+            checked = " checked" if value else ""
+            parts.append(f"  <input{_attr_str(input_attrs)}{checked}>")
 
         else:
             val_attr = f' value="{escape(str(value))}"' if value is not None else ""
@@ -508,9 +524,15 @@ class AirForm[M: BaseModel]:
                 self.errors = [{"type": "value_error", "loc": (CSRF_FIELD_NAME,), "msg": str(e), "input": raw_token}]
                 return self.is_valid
 
+        # Coerce bool fields for HTML checkbox behavior:
+        # checked -> "on", unchecked -> key missing entirely
+        assert self.model is not None
+        for field_name, field_info in self.model.model_fields.items():
+            if field_info.annotation is bool and field_name not in self.submitted_data:
+                self.submitted_data[field_name] = False
+
         # Validate against the user's model
         try:
-            assert self.model is not None
             self._data = self.model(**self.submitted_data)
             self.is_valid = True
         except ValidationError as e:

--- a/src/air/form/main.py
+++ b/src/air/form/main.py
@@ -83,6 +83,16 @@ def _is_optional(annotation: Any) -> bool:
     return False
 
 
+def _is_bool(annotation: Any) -> bool:
+    """Return True if annotation is ``bool`` or ``bool | None``."""
+    if annotation is bool:
+        return True
+    if _is_optional(annotation):
+        args = get_args(annotation)
+        return bool in args
+    return False
+
+
 # ---------------------------------------------------------------------------
 # Type and option helpers
 # ---------------------------------------------------------------------------
@@ -115,7 +125,7 @@ def pydantic_type_to_html_type(field_info: Any) -> str:
         return "select"
 
     annotation = field_info.annotation
-    if annotation is bool:
+    if _is_bool(annotation):
         return "checkbox"
     if annotation is int or annotation is float:
         return "number"
@@ -528,7 +538,7 @@ class AirForm[M: BaseModel]:
         # checked -> "on", unchecked -> key missing entirely
         assert self.model is not None
         for field_name, field_info in self.model.model_fields.items():
-            if field_info.annotation is bool and field_name not in self.submitted_data:
+            if _is_bool(field_info.annotation) and field_name not in self.submitted_data:
                 self.submitted_data[field_name] = False
 
         # Validate against the user's model

--- a/tests/test_form.py
+++ b/tests/test_form.py
@@ -250,6 +250,36 @@ def test_pydantic_type_to_html_type() -> None:
     assert pydantic_type_to_html_type(TestModel.model_fields["active"]) == "checkbox"
 
 
+def test_pydantic_type_to_html_type_semantic_widgets() -> None:
+    """Semantic widget names map to valid HTML input types."""
+
+    class WidgetModel(BaseModel):
+        on_off: bool = AirField(widget="toggle")
+        intensity: int = AirField(widget="slider")
+        mobile: str = AirField(widget="phone")
+        price: float = AirField(widget="currency")
+        query: str = AirField(widget="search")
+        notes: str = AirField(widget="rich_text")
+        source: str = AirField(widget="code")
+
+    assert pydantic_type_to_html_type(WidgetModel.model_fields["on_off"]) == "checkbox"
+    assert pydantic_type_to_html_type(WidgetModel.model_fields["intensity"]) == "range"
+    assert pydantic_type_to_html_type(WidgetModel.model_fields["mobile"]) == "tel"
+    assert pydantic_type_to_html_type(WidgetModel.model_fields["price"]) == "number"
+    assert pydantic_type_to_html_type(WidgetModel.model_fields["query"]) == "search"
+    assert pydantic_type_to_html_type(WidgetModel.model_fields["notes"]) == "textarea"
+    assert pydantic_type_to_html_type(WidgetModel.model_fields["source"]) == "textarea"
+
+
+def test_pydantic_type_to_html_type_unknown_widget_passes_through() -> None:
+    """Unknown widget kinds pass through as-is (e.g. valid HTML types like 'date')."""
+
+    class DateModel(BaseModel):
+        birthday: str = AirField(type="date")
+
+    assert pydantic_type_to_html_type(DateModel.model_fields["birthday"]) == "date"
+
+
 # ── Render tests: Daniel's pattern + full AirField vocabulary ────────
 
 
@@ -451,6 +481,77 @@ def test_render_checkbox() -> None:
     input_pos = html.index("<input")
     label_pos = html.index("<label")
     assert input_pos < label_pos
+
+
+def test_render_checkbox_checked_when_true() -> None:
+    """Checkbox renders with 'checked' attribute when value is True."""
+
+    class WaiverModel(BaseModel):
+        accepted: bool = AirField(default=False, label="Accept terms")
+
+    html = default_form_widget(model=WaiverModel, data={"accepted": True})
+    assert "checked" in html
+    assert 'value="True"' not in html  # uses checked, not value
+
+
+def test_render_checkbox_unchecked_when_false() -> None:
+    """Checkbox renders without 'checked' when value is False."""
+
+    class WaiverModel(BaseModel):
+        accepted: bool = AirField(default=False, label="Accept terms")
+
+    html = default_form_widget(model=WaiverModel, data={"accepted": False})
+    assert "checked" not in html
+
+
+def test_render_toggle_widget_as_checkbox() -> None:
+    """widget='toggle' renders as a checkbox input."""
+
+    class SettingsModel(BaseModel):
+        is_public: bool = AirField(default=True, widget="toggle", label="Public")
+
+    class SettingsForm(AirForm[SettingsModel]):
+        pass
+
+    html = SettingsForm().render()
+    assert 'type="checkbox"' in html
+    # Label after input (checkbox behavior)
+    input_pos = html.index("<input")
+    label_pos = html.index("<label")
+    assert input_pos < label_pos
+
+
+def test_validate_unchecked_checkbox_is_false() -> None:
+    """Unchecked checkboxes send nothing; missing bool fields become False."""
+
+    class WaiverModel(BaseModel):
+        name: str
+        accepted: bool = AirField(default=True)
+
+    class WaiverForm(AirForm[WaiverModel]):
+        pass
+
+    form = WaiverForm()
+    # HTML checkbox omits the field entirely when unchecked
+    form.validate({"name": "Audrey"})
+    assert form.is_valid
+    assert form.data.accepted is False
+
+
+def test_validate_checked_checkbox_is_true() -> None:
+    """Checked checkboxes send 'on'; Pydantic coerces to True."""
+
+    class WaiverModel(BaseModel):
+        name: str
+        accepted: bool = AirField(default=False)
+
+    class WaiverForm(AirForm[WaiverModel]):
+        pass
+
+    form = WaiverForm()
+    form.validate({"name": "Audrey", "accepted": "on"})
+    assert form.is_valid
+    assert form.data.accepted is True
 
 
 def test_render_optional_not_required() -> None:

--- a/tests/test_form.py
+++ b/tests/test_form.py
@@ -554,6 +554,47 @@ def test_validate_checked_checkbox_is_true() -> None:
     assert form.data.accepted is True
 
 
+def test_optional_bool_renders_as_checkbox() -> None:
+    """bool | None fields render as checkboxes, not text inputs."""
+
+    class ConsentModel(BaseModel):
+        agreed: bool | None = None
+
+    assert pydantic_type_to_html_type(ConsentModel.model_fields["agreed"]) == "checkbox"
+
+
+def test_optional_bool_unchecked_is_false() -> None:
+    """Unchecked optional bool becomes False, not None."""
+
+    class ConsentModel(BaseModel):
+        name: str
+        agreed: bool | None = None
+
+    class ConsentForm(AirForm[ConsentModel]):
+        pass
+
+    form = ConsentForm()
+    form.validate({"name": "Audrey"})
+    assert form.is_valid
+    assert form.data.agreed is False
+
+
+def test_optional_bool_checked_is_true() -> None:
+    """Checked optional bool becomes True."""
+
+    class ConsentModel(BaseModel):
+        name: str
+        agreed: bool | None = None
+
+    class ConsentForm(AirForm[ConsentModel]):
+        pass
+
+    form = ConsentForm()
+    form.validate({"name": "Audrey", "agreed": "on"})
+    assert form.is_valid
+    assert form.data.agreed is True
+
+
 def test_render_optional_not_required() -> None:
     class CompanionModel(BaseModel):
         catchphrase: str | None = None

--- a/tests/test_form.py
+++ b/tests/test_form.py
@@ -538,6 +538,22 @@ def test_validate_unchecked_checkbox_is_false() -> None:
     assert form.data.accepted is False
 
 
+def test_validate_required_bool_unchecked_is_false() -> None:
+    """Required bool with no default still validates; unchecked means False."""
+
+    class AgreementModel(BaseModel):
+        name: str
+        agreed: bool
+
+    class AgreementForm(AirForm[AgreementModel]):
+        pass
+
+    form = AgreementForm()
+    form.validate({"name": "Audrey"})
+    assert form.is_valid
+    assert form.data.agreed is False
+
+
 def test_validate_checked_checkbox_is_true() -> None:
     """Checked checkboxes send 'on'; Pydantic coerces to True."""
 
@@ -593,6 +609,48 @@ def test_optional_bool_checked_is_true() -> None:
     form.validate({"name": "Audrey", "agreed": "on"})
     assert form.is_valid
     assert form.data.agreed is True
+
+
+def test_validate_two_bools_one_checked_one_unchecked() -> None:
+    """Each bool field is coerced independently."""
+
+    class PrefsModel(BaseModel):
+        name: str
+        newsletter: bool = AirField(default=False)
+        terms: bool = AirField(default=False)
+
+    class PrefsForm(AirForm[PrefsModel]):
+        pass
+
+    form = PrefsForm()
+    form.validate({"name": "Audrey", "newsletter": "on"})
+    assert form.is_valid
+    assert form.data.newsletter is True
+    assert form.data.terms is False
+
+
+def test_render_slider_widget() -> None:
+    """widget='slider' renders as a range input with value, not checked."""
+
+    class MixerModel(BaseModel):
+        volume: int = AirField(default=50, widget="slider", label="Volume")
+
+    html = default_form_widget(model=MixerModel, data={"volume": 75})
+    assert 'type="range"' in html
+    assert 'value="75"' in html
+    assert "checked" not in html
+
+
+def test_render_rich_text_widget_as_textarea() -> None:
+    """widget='rich_text' renders as a textarea element."""
+
+    class PostModel(BaseModel):
+        body: str = AirField(widget="rich_text", label="Body")
+
+    html = default_form_widget(model=PostModel, data={"body": "Hello"})
+    assert "<textarea" in html
+    assert "Hello</textarea>" in html
+    assert "<input" not in html
 
 
 def test_render_optional_not_required() -> None:


### PR DESCRIPTION
## Summary

AirForm previously passed semantic widget names like `toggle` and `slider` straight through to `type=`, producing invalid HTML attributes. Checkboxes also rendered with `value=` instead of the `checked` attribute, and unchecked checkboxes (which browsers omit from form data entirely) were never coerced to `False` during validation.

This branch adds a `_WIDGET_TO_HTML_TYPE` mapping that translates semantic widget names to valid HTML input types (toggle to checkbox, slider to range, phone to tel, etc.), a dedicated checkbox rendering path that uses `checked`/unchecked instead of `value=`, and bool-field coercion in `AirForm.validate()` so missing checkboxes round-trip as `False`.

## Test plan

- [x] Tests for semantic widget mapping (toggle, slider, phone, currency, search, rich_text, code)
- [x] Test that unknown widget kinds pass through as-is
- [x] Tests for checkbox rendering with checked/unchecked states
- [x] Tests for toggle widget rendering as checkbox
- [x] Tests for unchecked checkbox validating as `False`
- [x] Tests for checked checkbox (`"on"`) validating as `True`