### PR TITLE
Fix for docs not building

### DIFF
--- a/docs/api/forms.md
+++ b/docs/api/forms.md
@@ -1,3 +1,3 @@
 # Forms
 
-::: air.forms
+::: air.form

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -88,7 +88,7 @@ dependencies = [
     "lxml>=6.0.2", # https://pypi.org/project/lxml
     "minify-html>=0.18.1", # https://pypi.org/project/minify-html
     "nh3>=0.3.2", # https://pypi.org/project/nh3
-    "pygments>=2.19.2", # https://pypi.org/project/pygments
+    "pygments==2.19.2", # https://pypi.org/project/pygments
     "python-multipart>=0.0.22", # https://pypi.org/project/python-multipart
     "rich>=14.3.2", # https://pypi.org/project/rich
     "selectolax>=0.4.6", # https://pypi.org/project/selectolax

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -88,7 +88,7 @@ dependencies = [
     "lxml>=6.0.2", # https://pypi.org/project/lxml
     "minify-html>=0.18.1", # https://pypi.org/project/minify-html
     "nh3>=0.3.2", # https://pypi.org/project/nh3
-    "pygments==2.19.2", # https://pypi.org/project/pygments
+    "pygments>=2.19.2,!=2.20.0", # https://pypi.org/project/pygments
     "python-multipart>=0.0.22", # https://pypi.org/project/python-multipart
     "rich>=14.3.2", # https://pypi.org/project/rich
     "selectolax>=0.4.6", # https://pypi.org/project/selectolax

--- a/tests/test_docs.py
+++ b/tests/test_docs.py
@@ -13,6 +13,8 @@ def test_documentation_builds(tmp_path: Path) -> None:
     subprocess.run(
         [
             sys.executable,
+            "-X",
+            "utf8",
             "-m",
             "mkdocs",
             "build",

--- a/tests/test_docs.py
+++ b/tests/test_docs.py
@@ -1,0 +1,25 @@
+"""Documentation integration tests."""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_documentation_builds(tmp_path: Path) -> None:
+    subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "mkdocs",
+            "build",
+            "--strict",
+            "--site-dir",
+            str(tmp_path),
+        ],
+        cwd=PROJECT_ROOT,
+        check=True,
+    )

--- a/uv.lock
+++ b/uv.lock
@@ -106,7 +106,7 @@ requires-dist = [
     { name = "lxml", specifier = ">=6.0.2" },
     { name = "minify-html", specifier = ">=0.18.1" },
     { name = "nh3", specifier = ">=0.3.2" },
-    { name = "pygments", specifier = ">=2.19.2" },
+    { name = "pygments", specifier = "==2.19.2" },
     { name = "python-multipart", specifier = ">=0.0.22" },
     { name = "rich", specifier = ">=14.3.2" },
     { name = "selectolax", specifier = ">=0.4.6" },
@@ -1878,11 +1878,11 @@ wheels = [
 
 [[package]]
 name = "pygments"
-version = "2.20.0"
+version = "2.19.2"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/c3/b2/bc9c9196916376152d655522fdcebac55e66de6603a76a02bca1b6414f6c/pygments-2.20.0.tar.gz", hash = "sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f", size = 4955991, upload-time = "2026-03-29T13:29:33.898Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/b0/77/a5b8c569bf593b0140bde72ea885a803b82086995367bf2037de0159d924/pygments-2.19.2.tar.gz", hash = "sha256:636cb2477cec7f8952536970bc533bc43743542f70392ae026374600add5b887", size = 4968631, upload-time = "2025-06-21T13:39:12.283Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/f4/7e/a72dd26f3b0f4f2bf1dd8923c85f7ceb43172af56d63c7383eb62b332364/pygments-2.20.0-py3-none-any.whl", hash = "sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176", size = 1231151, upload-time = "2026-03-29T13:29:30.038Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/21/705964c7812476f378728bdf590ca4b771ec72385c533964653c68e86bdc/pygments-2.19.2-py3-none-any.whl", hash = "sha256:86540386c03d588bb81d44bc3928634ff26449851e99741617ecb9037ee5ec0b", size = 1225217, upload-time = "2025-06-21T13:39:07.939Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -106,7 +106,7 @@ requires-dist = [
     { name = "lxml", specifier = ">=6.0.2" },
     { name = "minify-html", specifier = ">=0.18.1" },
     { name = "nh3", specifier = ">=0.3.2" },
-    { name = "pygments", specifier = "==2.19.2" },
+    { name = "pygments", specifier = ">=2.19.2,!=2.20.0" },
     { name = "python-multipart", specifier = ">=0.0.22" },
     { name = "rich", specifier = ">=14.3.2" },
     { name = "selectolax", specifier = ">=0.4.6" },


### PR DESCRIPTION
<!--
Before submitting:
- Read CONTRIBUTING.md for workflow
- Read AGENTS.md for architecture (especially if AI-generated)

Air's design principles: semantic APIs with clear docstrings,
concise docs mindful of context window sizes, max readability,
less code is better, zero config is ideal. — airwebframework.org
-->

## What

Pygments 2.20.0 has a breaking change that prevents Air's documentation from building. This PR excludes only that release with `pygments>=2.19.2,!=2.20.0`; the lockfile stays on working version 2.19.2 until a newer fixed release is available. Reference: https://github.com/pygments/pygments/issues/3076

This PR also fixes the misspelled `air.forms` documentation reference and adds an integration test that builds the complete documentation site with MkDocs.

## Reviewer Focus

The constraint excludes the known-bad 2.20.0 release while automatically permitting 2.20.1 or later once published, so no follow-up constraint change is required.

## Checklist

- [X] Diff contains only changes for this task — no unrelated refactoring or cleanup
- [ ] Addresses exactly one issue or feature
- [X] New or changed behavior has test coverage
- [X] This is the simplest viable approach
- [X] AI provenance section removed or accurate
