### PR TITLE
Fix AirModel example custom widget binding

### DIFF
--- a/examples/src/models__AirModel__to_form.py
+++ b/examples/src/models__AirModel__to_form.py
@@ -27,7 +27,7 @@ def custom_widget(
 
 class ContactForm(AirForm[ContactModel]):
     excludes = (("phone", "display"),)  # Don't render phone, but keep it in save_data
-    widget = custom_widget
+    widget = staticmethod(custom_widget)
 
 
 @app.page


### PR DESCRIPTION
## Summary

- preserve `custom_widget` as a plain callable with `staticmethod()` on `ContactForm`
- restore the `AirModel.to_form` source example's rendering test

## Why

The example assigns a module-level function as a form class attribute. Python's descriptor binding then injects the form instance as a positional argument, but the custom widget accepts keyword-only arguments, so rendering raises `TypeError`.

## Impact

The example page renders again, and its three focused regression tests pass.

## Validation

- `uv run pytest examples/src/models__AirModel__to_form__test.py -q` — 3 passed
- `uv run pytest -q` — 699 passed
- `uv run ruff format --check .`
- `uv run ruff check .`
- `uv run ty check`

Closes #862
